### PR TITLE
Fix Chart.js loading to avoid CORS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Modernizuotas vieno HTML failo informacinis skydelis, kuris užkrauna neatidėliotinos pagalbos skyriaus duomenis iš „Google Sheets“ CSV ir pateikia pagrindinius rodiklius, grafikus bei savaitinę suvestinę.
 
 ## Savybės
-- 🔄 Vienas HTML failas be papildomų priklausomybių (Chart.js tiekiamas iš CDN).
+- 🔄 Vienas HTML failas be papildomų priklausomybių (Chart.js kraunamas iš CDN per klasikinį `<script>`, kad neliktų CORS/MIME kliūčių).
 - 📊 KPI kortelės, stulpelinė bei linijinė diagramos, savaitinė lentelė.
 - 🧭 LT lokalė, aiškūs paaiškinimai, pritaikyta klaviatūros ir ekrano skaitytuvų naudotojams.
 - 🖥️ Reagavimas į ekranų pločius (desktop, planšetė, telefonas), „prefers-reduced-motion“ palaikymas.

--- a/index.html
+++ b/index.html
@@ -415,15 +415,38 @@
   </footer>
 
   <script type="module">
-    const chartJsPromise = import('https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.esm.js')
-      .then((module) => {
-        module.Chart.register(...module.registerables);
-        return module.Chart;
-      })
-      .catch((error) => {
-        console.error('Nepavyko įkelti Chart.js modulio:', error);
-        return null;
-      });
+    /**
+     * Įkelia Chart.js iš CDN naudojant klasikinį <script>, kad išvengtume CORS/MIME klaidų.
+     * Jei biblioteka jau užkrauta (pvz., iš ankstesnio seanso), panaudojamas esamas egzempliorius.
+     * @returns {Promise<typeof window.Chart|null>}
+     */
+    let chartJsPromise = null;
+
+    function loadChartJs() {
+      if (window.Chart) {
+        return Promise.resolve(window.Chart);
+      }
+
+      if (!chartJsPromise) {
+        chartJsPromise = new Promise((resolve) => {
+          const script = document.createElement('script');
+          script.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';
+          script.async = true;
+          script.onload = () => resolve(window.Chart ?? null);
+          script.onerror = (error) => {
+            console.error('Nepavyko įkelti Chart.js bibliotekos:', error);
+            chartJsPromise = null;
+            resolve(null);
+          };
+          document.head.appendChild(script);
+        });
+      }
+
+      return chartJsPromise;
+    }
+
+    // Iškart inicijuojame įkėlimą, kad biblioteka būtų paruošta, kai prireiks piešti grafikus.
+    loadChartJs();
     /**
      * Konfigūracija tekstams ir greitiems pakeitimams (LT numatytasis, lengva išplėsti EN).
      */
@@ -694,7 +717,7 @@
     }
 
     async function renderCharts(dailyStats) {
-      const Chart = await chartJsPromise;
+      const Chart = await loadChartJs();
       if (!Chart) {
         throw new Error('Chart.js biblioteka nepasiekiama');
       }


### PR DESCRIPTION
## Summary
- replace the dynamic ES module import with a resilient script-based loader so Chart.js can load without CORS/MIME errors
- trigger the loader early and allow retries if the CDN was temporarily unreachable
- document the updated loading approach in the README

## Testing
- not run (static HTML dashboard)

------
https://chatgpt.com/codex/tasks/task_e_68d38e91053c8320b9ff3372cbfe6a6b