### PR TITLE
Improve data loading resilience with fallback sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,32 @@ Modernizuotas vieno HTML failo informacinis skydelis, kuris užkrauna neatidėli
 - 📊 KPI kortelės, stulpelinė bei linijinė diagramos, savaitinė lentelė.
 - 🧭 LT lokalė, aiškūs paaiškinimai, pritaikyta klaviatūros ir ekrano skaitytuvų naudotojams.
 - 🖥️ Reagavimas į ekranų pločius (desktop, planšetė, telefonas), „prefers-reduced-motion“ palaikymas.
+- 🛡️ Automatinis demonstracinių duomenų rezervas ir aiškios klaidų žinutės, padedančios diagnozuoti „Google Sheets“ publikavimo problemas.
 
 ## Diegimas
 1. Atsisiųskite saugomą saugyklą arba jos ZIP: `git clone https://example.com/ed_stats_dashboard.git`.
 2. Atidarykite `index.html` pasirinktoje naršyklėje (Chrome, Edge, Firefox).
-3. Jei reikia naudoti kitą duomenų šaltinį, pakoreguokite `fetchData()` funkcijos `url` reikšmę (`index.html`, komentaras nurodytas kode).
+3. Jei reikia naudoti kitą duomenų šaltinį, `index.html` faile suraskite `const DATA_SOURCE` ir pakeiskite `url` reikšmę „Publish to web → CSV“ nuoroda.
+4. Jeigu norite išjungti ar atnaujinti demonstracinius duomenis, tame pačiame `DATA_SOURCE` bloke redaguokite `fallbackCsv` (tuščia reikšmė – jokių rezervinių duomenų).
 
 ## Konfigūracija
 - Tekstai (LT, su kabliuku EN) – `TEXT` objektas `index.html` viršuje.
+- Duomenų šaltinis ir demonstraciniai įrašai – `DATA_SOURCE` objektas (tas pats failas, viršuje prie skripto).
 - Spalvų schema ir kampai – CSS kintamieji `:root` bloke (`index.html`).
 - Grafikai – Chart.js nustatymai `renderCharts()` funkcijoje (`index.html`).
+
+## Trikčių diagnostika
+- Statuso eilutė praneš „Rodomi demonstraciniai duomenys…“, jei nepavyko pasiekti nuotolinio CSV (HTTP 404/403, CORS, tinklo klaidos).
+- Raudonas pranešimas rodo kritinę klaidą. Patikrinkite, ar Google Sheet yra paviešinta per **File → Share → Publish to web → CSV** ir ar nuoroda atsidaro naršyklėje be prisijungimo.
+- Naršyklės konsolėje matysite lokalizuotą klaidos paaiškinimą (pvz., „HTTP 404 – nuoroda nerasta“). Tai padeda greitai sutaisyti leidimų problemas.
+- Rezervinį duomenų rinkinį galite išjungti (perduoti tuščią `fallbackCsv`), jei norite matyti tik realią klaidos būseną.
 
 ## Greitas „smoke test“ sąrašas
 1. Atidarykite `index.html` ir patikrinkite, kad hero blokas rodo pavadinimą bei mygtuką „Perkrauti duomenis“.
 2. Patvirtinkite, kad užsikrovus duomenims KPI kortelės užsipildo, grafikai nupiešiami, lentelė rodoma.
 3. Paspauskite „Perkrauti duomenis“ – statusas turi trumpam rodyti „Kraunama...“, po sėkmės – atnaujinimo laiką.
-4. Išjunkite internetą ir paspauskite „Perkrauti duomenis“ – turi būti matomas klaidos pranešimas hero bloke ir konsolėje.
+4. Laikinai atjunkite internetą ir spauskite „Perkrauti duomenis“ – statusas turi pereiti į oranžinę žinutę apie demonstracinius duomenis, konsolėje matysite klaidos detalizaciją.
+5. (Pasirinktinai) Išvalykite `fallbackCsv` ir pakartokite 4 žingsnį – statusas turi tapti raudonas su konkrečiu klaidos aprašymu.
 
 ## Licencija
 Projektas licencijuojamas pagal [MIT](./LICENSE) licenciją. Drąsiai naudokite, adaptuokite ir diekite RŠL bei kitose gydymo įstaigose.

--- a/index.html
+++ b/index.html
@@ -131,6 +131,34 @@
       font-weight: 600;
     }
 
+    .status-note {
+      margin: 0;
+      font-size: 0.82rem;
+      line-height: 1.4;
+      padding: 8px 12px;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      background: rgba(255, 255, 255, 0.16);
+      color: #fff;
+      backdrop-filter: blur(4px);
+    }
+
+    .status-note[hidden] {
+      display: none;
+    }
+
+    .status-note[data-tone="warning"] {
+      background: rgba(251, 191, 36, 0.22);
+      border-color: rgba(251, 191, 36, 0.45);
+      color: #0f172a;
+    }
+
+    .status-note[data-tone="error"] {
+      background: rgba(248, 113, 113, 0.28);
+      border-color: rgba(248, 113, 113, 0.55);
+      color: #fff;
+    }
+
     main {
       flex: 1;
       padding: 40px 0 64px;
@@ -347,6 +375,7 @@
           <span id="refreshText">Perkrauti duomenis</span>
         </button>
         <p id="status" class="status" role="status" aria-live="polite">Kraunama...</p>
+        <p id="statusNote" class="status-note" role="note" aria-live="polite" hidden></p>
       </div>
     </div>
   </header>
@@ -448,6 +477,38 @@
     // Iškart inicijuojame įkėlimą, kad biblioteka būtų paruošta, kai prireiks piešti grafikus.
     loadChartJs();
     /**
+     * Pagrindinės duomenų konfigūracijos: nuotolinis CSV adresas ir vietinis demonstracinis rinkinys.
+     * Jei norite naudoti kitą Google Sheet, pakeiskite `url` reikšmę (privaloma „Publish to web → CSV“ nuoroda).
+     */
+    const DATA_SOURCE = {
+      url: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vS8xfS3FxpD5pT6rm-ClSf9DjV3usXjvJG4uKj7aC3_QtThtXidQZaN0ZQe9SEM0XB94XeLshwwLUSW/pub?gid=706041848&single=true&output=csv',
+      requiredColumns: [
+        'Atvykimo data',
+        'Išrašymo data',
+        'Diena/naktis',
+        'GMP',
+        'Nukreiptas į padalinį',
+      ],
+      fallbackCsv: `Atvykimo data,Išrašymo data,Diena/naktis,GMP,Nukreiptas į padalinį
+2024-02-01T07:15:00+02:00,2024-02-01T10:45:00+02:00,Diena,TAIP,Chirurgija
+2024-02-01T13:20:00+02:00,2024-02-01T16:00:00+02:00,Diena,NE,
+2024-02-01T21:10:00+02:00,2024-02-02T00:30:00+02:00,Naktis,TAIP,Traumatologija
+2024-02-02T06:55:00+02:00,2024-02-02T09:10:00+02:00,Diena,NE,
+2024-02-02T18:40:00+02:00,2024-02-02T22:05:00+02:00,Vakare,TAIP,Chirurgija
+2024-02-03T02:30:00+02:00,2024-02-03T05:00:00+02:00,Naktis,NE,
+2024-02-03T10:15:00+02:00,2024-02-03T13:20:00+02:00,Diena,NE,
+2024-02-04T08:05:00+02:00,2024-02-04T11:15:00+02:00,Diena,TAIP,Chirurgija
+2024-02-04T17:50:00+02:00,2024-02-04T21:30:00+02:00,Vakare,NE,
+2024-02-05T00:40:00+02:00,2024-02-05T04:10:00+02:00,Naktis,TAIP,Reanimacija
+2024-02-05T12:25:00+02:00,2024-02-05T15:45:00+02:00,Diena,NE,
+2024-02-06T07:55:00+02:00,2024-02-06T10:35:00+02:00,Diena,TAIP,Chirurgija
+2024-02-06T22:20:00+02:00,2024-02-07T01:40:00+02:00,Naktis,NE,
+2024-02-07T14:10:00+02:00,2024-02-07T18:55:00+02:00,Diena,NE,
+2024-02-08T05:50:00+02:00,2024-02-08T09:15:00+02:00,Rytas,TAIP,
+2024-02-08T19:30:00+02:00,2024-02-08T23:05:00+02:00,Vakare,NE,
+2024-02-09T23:10:00+02:00,2024-02-10T02:20:00+02:00,Naktis,TAIP,Traumatologija`,
+    };
+    /**
      * Konfigūracija tekstams ir greitiems pakeitimams (LT numatytasis, lengva išplėsti EN).
      */
     const TEXT = {
@@ -458,8 +519,13 @@
         loading: 'Kraunama...',
         error: 'Nepavyko įkelti duomenų. Patikrinkite ryšį ir bandykite dar kartą.',
         success: (timestamp) => `Atnaujinta ${timestamp}`,
+        fallbackSuccess: (timestamp) => `Rodomi demonstraciniai duomenys (bandyta ${timestamp})`,
+        fallbackNote: (reason) => `Nepavyko pasiekti nuotolinio šaltinio: ${reason}.`,
+        errorDetails: (details) => `Nepavyko įkelti duomenų${details ? ` (${details})` : ''}.`,
+        errorAdvice: 'Patikrinkite, ar „Google Sheet“ paskelbta pasirinkus „File → Share → Publish to web → CSV“.',
       },
       footer: (timestamp) => `Atnaujinta ${timestamp}`,
+      footerFallback: (timestamp) => `Rodoma demonstracinė versija (atnaujinta ${timestamp})`,
       kpis: {
         title: 'Pagrindiniai rodikliai',
         subtitle: 'Pastarųjų 30 dienų dinamika',
@@ -495,6 +561,7 @@
       subtitle: document.getElementById('pageSubtitle'),
       refreshText: document.getElementById('refreshText'),
       status: document.getElementById('status'),
+      statusNote: document.getElementById('statusNote'),
       footerUpdated: document.getElementById('footerUpdated'),
       kpiHeading: document.getElementById('kpiHeading'),
       kpiSubtitle: document.getElementById('kpiSubtitle'),
@@ -516,6 +583,8 @@
         daily: null,
         dow: null,
       },
+      usingFallback: false,
+      lastErrorMessage: '',
     };
 
     /**
@@ -533,68 +602,299 @@
       selectors.dowCaption.textContent = TEXT.charts.dowCaption;
       selectors.weeklyHeading.textContent = TEXT.weekly.title;
       selectors.weeklySubtitle.textContent = TEXT.weekly.subtitle;
+      hideStatusNote();
     }
 
     /**
      * Pagalbinė funkcija būsenos juostai atnaujinti.
      * @param {('loading'|'success'|'error')} type
+     * @param {string} [details]
      */
-    function setStatus(type) {
+    function hideStatusNote() {
+      if (!selectors.statusNote) return;
+      selectors.statusNote.textContent = '';
+      selectors.statusNote.dataset.tone = 'info';
+      selectors.statusNote.setAttribute('hidden', 'hidden');
+    }
+
+    function showStatusNote(message, tone = 'info') {
+      if (!selectors.statusNote) return;
+      if (!message) {
+        hideStatusNote();
+        return;
+      }
+      selectors.statusNote.textContent = message;
+      selectors.statusNote.dataset.tone = tone;
+      selectors.statusNote.removeAttribute('hidden');
+    }
+
+    function setStatus(type, details = '') {
       if (type === 'loading') {
         selectors.status.textContent = TEXT.status.loading;
         selectors.status.classList.remove('status--error');
+        hideStatusNote();
         return;
       }
 
       if (type === 'error') {
-        selectors.status.textContent = TEXT.status.error;
+        const message = details ? TEXT.status.errorDetails(details) : TEXT.status.error;
+        selectors.status.textContent = message;
         selectors.status.classList.add('status--error');
-        selectors.footerUpdated.textContent = TEXT.status.error;
+        selectors.footerUpdated.textContent = message;
+        showStatusNote(TEXT.status.errorAdvice, 'error');
         return;
       }
 
       const formatted = statusTimeFormatter.format(new Date());
-      selectors.status.textContent = TEXT.status.success(formatted);
       selectors.status.classList.remove('status--error');
-      selectors.footerUpdated.textContent = TEXT.footer(formatted);
+      if (dashboardState.usingFallback) {
+        selectors.status.textContent = TEXT.status.fallbackSuccess(formatted);
+        selectors.footerUpdated.textContent = TEXT.footerFallback(formatted);
+        const noteMessage = dashboardState.lastErrorMessage
+          ? TEXT.status.fallbackNote(dashboardState.lastErrorMessage)
+          : TEXT.status.fallbackNote(TEXT.status.error);
+        showStatusNote(noteMessage, 'warning');
+      } else {
+        selectors.status.textContent = details || TEXT.status.success(formatted);
+        selectors.footerUpdated.textContent = TEXT.footer(formatted);
+        hideStatusNote();
+      }
     }
 
     /**
-     * CSV duomenų užkrovimas iš Google Sheets. Jei reikalingas kitoks šaltinis – keiskite URL.
+     * CSV duomenų apdorojimo pagalbinės funkcijos: diagnostika, atsisiuntimas ir transformacija.
      */
-    async function fetchData() {
-      const url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vS8xfS3FxpD5pT6rm-ClSf9DjV3usXjvJG4uKj7aC3_QtThtXidQZaN0ZQe9SEMOXB94XeLshwwLUSW/pub?gid=706041848&single=true&output=csv';
-      const response = await fetch(url);
+    function describeError(error) {
+      if (!error) {
+        return TEXT.status.error;
+      }
+      const message = typeof error === 'string' ? error : error.message ?? TEXT.status.error;
+      if (/HTTP klaida:\s*404/.test(message)) {
+        return 'HTTP 404 – nuoroda nerasta arba dokumentas nepublikuotas.';
+      }
+      if (/HTTP klaida:\s*403/.test(message)) {
+        return 'HTTP 403 – prieiga uždrausta (patikrinkite bendrinimo teises).';
+      }
+      if (/Failed to fetch/i.test(message) || /NetworkError/i.test(message)) {
+        return 'Nepavyko pasiekti šaltinio (tinklo ar CORS apribojimas).';
+      }
+      if (/HTML atsakas/i.test(message)) {
+        return 'Gautas HTML atsakas vietoje CSV (reikia „Publish to web → CSV“ nuorodos).';
+      }
+      return message;
+    }
+
+    async function downloadCsv(url) {
+      const response = await fetch(url, { cache: 'no-store' });
       if (!response.ok) {
         throw new Error(`HTTP klaida: ${response.status}`);
       }
-      const text = await response.text();
-      const lines = text.trim().split(/\r?\n/);
-      const header = lines[0].split(',');
-      const rows = [];
-
-      for (let i = 1; i < lines.length; i += 1) {
-        const cols = lines[i].split(',');
-        if (cols.length !== header.length) continue;
-        const entry = {};
-        header.forEach((h, idx) => {
-          entry[h] = cols[idx];
-        });
-        entry.arrival = entry['Atvykimo data'] ? new Date(entry['Atvykimo data']) : null;
-        entry.discharge = entry['Išrašymo data'] ? new Date(entry['Išrašymo data']) : null;
-        entry.night = false;
-        if (entry['Diena/naktis']) {
-          entry.night = entry['Diena/naktis'].toLowerCase().includes('naktis');
-        } else if (entry.arrival instanceof Date && !Number.isNaN(entry.arrival)) {
-          const hour = entry.arrival.getHours();
-          entry.night = hour >= 20 || hour < 7;
-        }
-        const gmpVal = entry['GMP'] ? entry['GMP'].toLowerCase().trim() : '';
-        entry.ems = ['1', 'true', 'taip', 'yes', 'y'].includes(gmpVal);
-        entry.hospitalized = Boolean(entry['Nukreiptas į padalinį'] && entry['Nukreiptas į padalinį'].trim());
-        rows.push(entry);
+      const textContent = await response.text();
+      const contentType = response.headers.get('content-type') ?? '';
+      if (contentType.includes('text/html') || /^<!doctype html/i.test(textContent.trim())) {
+        throw new Error('HTML atsakas vietoje CSV – patikrinkite, ar nuoroda publikuota kaip CSV.');
       }
-      return rows;
+      return textContent;
+    }
+
+    function detectDelimiter(text) {
+      const sampleLine = text.split('\n').find((line) => line.trim().length > 0) ?? '';
+      const candidates = [',', ';', '\t', '|'];
+      let best = ',';
+      let bestScore = -1;
+      candidates.forEach((delimiter) => {
+        let inQuotes = false;
+        let score = 0;
+        for (let i = 0; i < sampleLine.length; i += 1) {
+          const char = sampleLine[i];
+          if (char === '"') {
+            if (inQuotes && sampleLine[i + 1] === '"') {
+              i += 1;
+            } else {
+              inQuotes = !inQuotes;
+            }
+          } else if (!inQuotes && char === delimiter) {
+            score += 1;
+          }
+        }
+        if (score > bestScore) {
+          bestScore = score;
+          best = delimiter;
+        }
+      });
+      return bestScore > 0 ? best : ',';
+    }
+
+    function parseCsv(text) {
+      const sanitized = text.replace(/\r\n/g, '\n');
+      const delimiter = detectDelimiter(sanitized);
+      const rows = [];
+      let current = [];
+      let value = '';
+      let inQuotes = false;
+      for (let i = 0; i < sanitized.length; i += 1) {
+        const char = sanitized[i];
+        if (char === '"') {
+          if (inQuotes && sanitized[i + 1] === '"') {
+            value += '"';
+            i += 1;
+          } else {
+            inQuotes = !inQuotes;
+          }
+          continue;
+        }
+        if (char === delimiter && !inQuotes) {
+          current.push(value);
+          value = '';
+          continue;
+        }
+        if (char === '\n' && !inQuotes) {
+          current.push(value);
+          rows.push(current);
+          current = [];
+          value = '';
+          continue;
+        }
+        value += char;
+      }
+      if (value.length > 0 || current.length) {
+        current.push(value);
+        rows.push(current);
+      }
+      const filteredRows = rows.filter((row) => row.some((cell) => (cell ?? '').trim().length > 0));
+      return { rows: filteredRows, delimiter };
+    }
+
+    function parseDate(value) {
+      if (!value) {
+        return null;
+      }
+      const raw = String(value).trim();
+      if (!raw) {
+        return null;
+      }
+      const isoCandidate = raw.includes('T') ? raw : raw.replace(' ', 'T');
+      let parsed = new Date(isoCandidate);
+      if (!Number.isNaN(parsed?.getTime?.())) {
+        return parsed;
+      }
+      const onlyDate = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      if (onlyDate) {
+        parsed = new Date(Number(onlyDate[1]), Number(onlyDate[2]) - 1, Number(onlyDate[3]));
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+      const european = raw.match(/^(\d{2})\.(\d{2})\.(\d{4})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?)?$/);
+      if (european) {
+        const [, day, month, year, hour = '0', minute = '0', second = '0'] = european;
+        parsed = new Date(
+          Number(year),
+          Number(month) - 1,
+          Number(day),
+          Number(hour),
+          Number(minute),
+          Number(second)
+        );
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      }
+      return null;
+    }
+
+    function parseBoolean(value) {
+      if (value == null) {
+        return false;
+      }
+      const normalized = String(value).trim().toLowerCase();
+      return ['1', 'true', 'taip', 't', 'yes', 'y'].includes(normalized);
+    }
+
+    function detectNight(dayNightValue, arrivalDate) {
+      if (dayNightValue) {
+        const normalized = String(dayNightValue).trim().toLowerCase();
+        if (normalized.includes('nakt')) {
+          return true;
+        }
+        if (normalized.includes('dien')) {
+          return false;
+        }
+      }
+      if (arrivalDate instanceof Date && !Number.isNaN(arrivalDate.getTime())) {
+        const hour = arrivalDate.getHours();
+        return hour >= 20 || hour < 7;
+      }
+      return false;
+    }
+
+    function mapRow(header, cols, delimiter) {
+      const normalized = [...cols];
+      if (normalized.length < header.length) {
+        normalized.push(...Array(header.length - normalized.length).fill(''));
+      } else if (normalized.length > header.length) {
+        const extras = normalized.splice(header.length - 1);
+        normalized[header.length - 1] = [normalized[header.length - 1], ...extras].join(delimiter);
+      }
+      const entry = {};
+      header.forEach((column, idx) => {
+        entry[column] = normalized[idx] != null ? String(normalized[idx]).trim() : '';
+      });
+      entry.arrival = parseDate(entry['Atvykimo data']);
+      entry.discharge = parseDate(entry['Išrašymo data']);
+      entry.night = detectNight(entry['Diena/naktis'], entry.arrival);
+      entry.ems = parseBoolean(entry['GMP']);
+      entry.hospitalized = Boolean(entry['Nukreiptas į padalinį'] && entry['Nukreiptas į padalinį'].trim());
+      return entry;
+    }
+
+    function transformCsv(text) {
+      if (!text) {
+        throw new Error('CSV turinys tuščias.');
+      }
+      const { rows, delimiter } = parseCsv(text);
+      if (!rows.length) {
+        throw new Error('CSV failas tuščias.');
+      }
+      const header = rows[0].map((cell) => String(cell ?? '').trim());
+      const missing = DATA_SOURCE.requiredColumns.filter((column) => !header.includes(column));
+      if (missing.length) {
+        throw new Error(`CSV faile trūksta laukų: ${missing.join(', ')}`);
+      }
+      const dataRows = rows.slice(1).filter((row) => row.some((cell) => (cell ?? '').trim().length > 0));
+      return dataRows.map((cols) => mapRow(header, cols, delimiter));
+    }
+
+    /**
+     * CSV duomenų užkrovimas iš Google Sheets (ar kito šaltinio) su demonstraciniu rezervu.
+     */
+    async function fetchData() {
+      const { url, fallbackCsv } = DATA_SOURCE;
+      if (!url) {
+        dashboardState.usingFallback = true;
+        dashboardState.lastErrorMessage = 'Nenurodytas duomenų URL.';
+        return transformCsv(fallbackCsv);
+      }
+      try {
+        const csvText = await downloadCsv(url);
+        const dataset = transformCsv(csvText);
+        dashboardState.usingFallback = false;
+        dashboardState.lastErrorMessage = '';
+        return dataset;
+      } catch (error) {
+        console.error('Nepavyko atsisiųsti CSV duomenų:', error);
+        dashboardState.lastErrorMessage = describeError(error);
+        if (fallbackCsv) {
+          try {
+            const dataset = transformCsv(fallbackCsv);
+            dashboardState.usingFallback = true;
+            return dataset;
+          } catch (fallbackError) {
+            console.error('Klaida skaitant demonstracinius duomenis:', fallbackError);
+            dashboardState.usingFallback = false;
+            dashboardState.lastErrorMessage = describeError(fallbackError);
+            throw fallbackError;
+          }
+        }
+        dashboardState.usingFallback = false;
+        throw error;
+      }
     }
 
     function computeDailyStats(data) {
@@ -885,7 +1185,10 @@
         setStatus('success');
       } catch (error) {
         console.error('Nepavyko apdoroti duomenų:', error);
-        setStatus('error');
+        dashboardState.usingFallback = false;
+        const friendlyMessage = describeError(error);
+        dashboardState.lastErrorMessage = friendlyMessage;
+        setStatus('error', friendlyMessage);
       }
     }
 


### PR DESCRIPTION
## Summary
- add a configurable data source block with a built-in demonstrational CSV fallback and richer status messaging
- harden CSV parsing/validation and surface friendly diagnostics plus fallback banners in the UI
- document the new configuration and troubleshooting workflow in the README

## Testing
- not run (static HTML project)


------
https://chatgpt.com/codex/tasks/task_e_68d39129c4f883209f65533c6c4e34eb