### PR TITLE
Fix chart canvases growing indefinitely

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,9 +310,16 @@
       color: var(--color-text-muted);
     }
 
-    canvas {
+    /* Fiksuotas grafiko aukštis, kad Chart.js neplėstų kanvos – keiskite jei reikia daugiau vietos. */
+    .chart-card canvas {
       width: 100% !important;
-      height: auto !important;
+      height: 320px !important;
+    }
+
+    @media (max-width: 768px) {
+      .chart-card canvas {
+        height: 260px !important;
+      }
     }
 
     .table-wrapper {


### PR DESCRIPTION
## Summary
- lock the chart canvas height so Chart.js cannot inflate it on each resize
- add a responsive breakpoint to keep charts shorter on narrow screens
- document in CSS comment where to tweak the height if needed

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d5171c0c94832094efcf1b97863463