### PR TITLE
Revise header styling and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,10 +38,10 @@
     }
 
     header.hero {
-      background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.18), transparent 55%),
-                  linear-gradient(135deg, #1d4ed8, #2563eb);
+      background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.16), transparent 55%),
+                  linear-gradient(135deg, #081231, #0b1d4d);
       color: #fff;
-      padding: 48px 0 36px;
+      padding: 32px 0 24px;
       position: relative;
       overflow: hidden;
     }
@@ -64,14 +64,14 @@
     }
 
     .hero__title {
-      font-size: clamp(1.9rem, 1.3rem + 1.5vw, 2.6rem);
+      font-size: clamp(1.6rem, 1.2rem + 1.1vw, 2.2rem);
       margin: 0 0 8px;
       letter-spacing: -0.01em;
     }
 
     .hero__subtitle {
       margin: 0;
-      font-size: 1rem;
+      font-size: 0.95rem;
       color: rgba(255, 255, 255, 0.9);
       max-width: 520px;
     }
@@ -80,31 +80,44 @@
       display: flex;
       flex-direction: column;
       align-items: flex-end;
-      gap: 12px;
+      gap: 10px;
     }
 
     .hero__buttons {
       display: flex;
-      flex-direction: column;
-      align-items: flex-end;
-      gap: 10px;
-      width: 100%;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    button.icon-button {
+      border: none;
+      border-radius: 50%;
+      width: 44px;
+      height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, border-color 0.3s ease;
+      box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.7);
+      padding: 0;
+    }
+
+    button.icon-button svg {
+      width: 22px;
+      height: 22px;
+    }
+
+    button.icon-button:focus-visible {
+      outline: 3px solid rgba(255, 255, 255, 0.6);
+      outline-offset: 3px;
     }
 
     button.refresh {
-      border: none;
-      border-radius: 999px;
       background: #fff;
       color: var(--color-accent);
-      font-weight: 600;
-      font-size: 0.95rem;
-      padding: 12px 20px;
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
-      box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.7);
     }
 
     button.refresh:hover,
@@ -112,59 +125,29 @@
       transform: translateY(-1px);
       box-shadow: 0 15px 35px -20px rgba(15, 23, 42, 0.75);
       background: rgba(255, 255, 255, 0.92);
-      outline: none;
     }
 
     button.refresh:active {
       transform: translateY(0);
     }
 
-    button.refresh span[aria-hidden="true"] {
-      font-size: 1.1rem;
-    }
-
-    button.refresh:focus-visible {
-      outline: 3px solid rgba(255, 255, 255, 0.6);
-      outline-offset: 3px;
-    }
-
     button.settings-btn {
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.12);
-      border: 1px solid rgba(255, 255, 255, 0.45);
+      background: rgba(255, 255, 255, 0.1);
+      border: 1px solid rgba(255, 255, 255, 0.35);
       color: #fff;
-      font-weight: 600;
-      font-size: 0.9rem;
-      padding: 10px 18px;
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, border-color 0.3s ease;
       box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.8);
-      text-decoration: none;
     }
 
     button.settings-btn:hover,
     button.settings-btn:focus-visible {
       transform: translateY(-1px);
-      box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.85);
       background: rgba(255, 255, 255, 0.18);
-      border-color: rgba(255, 255, 255, 0.75);
-      outline: none;
+      border-color: rgba(255, 255, 255, 0.65);
+      box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.85);
     }
 
     button.settings-btn:active {
       transform: translateY(0);
-    }
-
-    button.settings-btn span[aria-hidden="true"] {
-      font-size: 1rem;
-    }
-
-    button.settings-btn:focus-visible {
-      outline: 3px solid rgba(255, 255, 255, 0.6);
-      outline-offset: 3px;
     }
 
     .status {
@@ -614,17 +597,7 @@
 
       .hero__buttons {
         width: 100%;
-        align-items: stretch;
-      }
-
-      button.refresh {
-        width: 100%;
-        justify-content: center;
-      }
-
-      button.settings-btn {
-        width: 100%;
-        justify-content: center;
+        justify-content: flex-start;
       }
 
       .section__header {
@@ -680,13 +653,15 @@
       </div>
       <div class="hero__actions">
         <div class="hero__buttons">
-          <button id="openSettingsBtn" type="button" class="settings-btn" aria-haspopup="dialog" title="Atidaryti nustatymus (Ctrl+,)">
-            <span aria-hidden="true">⚙️</span>
-            <span>Nustatymai</span>
+          <button id="openSettingsBtn" type="button" class="icon-button settings-btn" aria-haspopup="dialog" aria-label="Atidaryti nustatymus" title="Atidaryti nustatymus (Ctrl+,)">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm9-3.5a1 1 0 0 0-.63-.92l-1.47-.6a7.06 7.06 0 0 0-.36-.88l.65-1.44a1 1 0 0 0-.12-1.05l-1.5-1.94a1 1 0 0 0-1.02-.35l-1.53.36a6.85 6.85 0 0 0-.76-.45l-.26-1.55A1 1 0 0 0 12.7 2h-3.4a1 1 0 0 0-.99.83l-.26 1.55a6.85 6.85 0 0 0-.76.45l-1.53-.36a1 1 0 0 0-1.02.35L3.24 6.76a1 1 0 0 0-.12 1.05l.65 1.44c-.14.29-.26.58-.36.88l-1.47.6A1 1 0 0 0 2 12c0 .4.24.76.61.92l1.47.6c.1.3.22.59.36.88l-.65 1.44a1 1 0 0 0 .12 1.05l1.5 1.94a1 1 0 0 0 1.02.35l1.53-.36c.25.17.5.32.76.45l.26 1.55c.08.46.48.81.95.81h3.4c.47 0 .87-.35.95-.81l.26-1.55c.26-.13.51-.28.76-.45l1.53.36a1 1 0 0 0 1.02-.35l1.5-1.94a1 1 0 0 0 .12-1.05l-.65-1.44c.14-.29.26-.58.36-.88l1.47-.6c.39-.16.63-.52.63-.92Z"/>
+            </svg>
           </button>
-          <button id="refreshBtn" type="button" class="refresh">
-            <span aria-hidden="true">⟳</span>
-            <span id="refreshText">Perkrauti duomenis</span>
+          <button id="refreshBtn" type="button" class="icon-button refresh" aria-label="Perkrauti duomenis" title="Perkrauti duomenis (R)">
+            <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+              <path fill="currentColor" d="M21 4v6h-6l2.24-2.24A6.97 6.97 0 0 0 5 12a7 7 0 0 0 12.59 4H19a1 1 0 1 1 0 2h-2a1 1 0 0 1-.8-.4A9 9 0 1 1 17.76 5.1L21 2v2Zm-9 5a1 1 0 0 1 .78.38l.07.1a1 1 0 0 1-.32 1.4l-.1.06A1 1 0 0 1 11 12a1 1 0 0 1-.78-.38l-.07-.1a1 1 0 0 1 .32-1.4l.1-.06A1 1 0 0 1 12 9Z"/>
+            </svg>
           </button>
         </div>
         <p id="status" class="status" role="status" aria-live="polite">Kraunama...</p>
@@ -1012,6 +987,7 @@
       title: 'Skubios pagalbos statistikos skydelis',
       subtitle: 'Greita neatidėliotinos pagalbos skyriaus darbo apžvalga be prisijungimo prie papildomų sistemų.',
       refresh: 'Perkrauti duomenis',
+      settings: 'Nustatymai',
       status: {
         loading: 'Kraunama...',
         error: 'Nepavyko įkelti duomenų. Patikrinkite ryšį ir bandykite dar kartą.',
@@ -1142,7 +1118,7 @@
     const selectors = {
       title: document.getElementById('pageTitle'),
       subtitle: document.getElementById('pageSubtitle'),
-      refreshText: document.getElementById('refreshText'),
+      refreshBtn: document.getElementById('refreshBtn'),
       status: document.getElementById('status'),
       statusNote: document.getElementById('statusNote'),
       footerUpdated: document.getElementById('footerUpdated'),
@@ -1669,7 +1645,14 @@
     function applyTextContent() {
       selectors.title.textContent = TEXT.title;
       selectors.subtitle.textContent = TEXT.subtitle;
-      selectors.refreshText.textContent = TEXT.refresh;
+      if (selectors.refreshBtn) {
+        selectors.refreshBtn.setAttribute('aria-label', TEXT.refresh);
+        selectors.refreshBtn.title = `${TEXT.refresh} (R)`;
+      }
+      if (selectors.openSettingsBtn) {
+        selectors.openSettingsBtn.setAttribute('aria-label', TEXT.settings);
+        selectors.openSettingsBtn.title = `${TEXT.settings} (Ctrl+,)`;
+      }
       selectors.kpiHeading.textContent = TEXT.kpis.title;
       selectors.kpiSubtitle.textContent = TEXT.kpis.subtitle;
       selectors.chartHeading.textContent = TEXT.charts.title;
@@ -2633,7 +2616,7 @@
 
     loadDashboard();
 
-    const refreshButton = document.getElementById('refreshBtn');
+    const refreshButton = selectors.refreshBtn;
     if (refreshButton) {
       refreshButton.addEventListener('click', () => {
         loadDashboard();


### PR DESCRIPTION
## Summary
- shrink the hero spacing and typography while switching the banner to a darker blue gradient
- restyle the refresh and settings actions as circular icon buttons with inline SVG artwork
- update the text binding logic so accessibility labels and shortcuts keep working without visible button text

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d52010a3d08320a36a5e672bd798f5