### PR TITLE
Adjust GMP defaults and ignore long stays

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Modernizuotas vieno HTML failo informacinis skydelis, kuris užkrauna neatidėli
 - 🖥️ Reagavimas į ekranų pločius (desktop, planšetė, telefonas), „prefers-reduced-motion“ palaikymas.
 - 🛡️ Automatinis demonstracinių duomenų rezervas ir aiškios klaidų žinutės, padedančios diagnozuoti „Google Sheets“ publikavimo problemas.
 - ⚙️ Nustatymų dialogas (Ctrl+,) CSV laukų, skaičiavimo logikos ir išvesties tekstų pritaikymui be kodo keitimo (saugoma `localStorage`).
+- 📈 Vidutinės buvimo trukmės apskaičiavimas automatiškai ignoruoja >24 val. įrašus, kad ekstremalios vertės nedarkytų rodiklių.
 
 ## Diegimas
 1. Atsisiųskite saugomą saugyklą arba jos ZIP: `git clone https://example.com/ed_stats_dashboard.git`.
@@ -18,6 +19,7 @@ Modernizuotas vieno HTML failo informacinis skydelis, kuris užkrauna neatidėli
 ## Konfigūracija
 - Tekstai (LT, su kabliuku EN) – `TEXT` objektas `index.html` viršuje arba nustatymų dialoge nurodyti pavadinimai/paantraštės.
 - Duomenų šaltinis, demonstraciniai įrašai ir CSV stulpelių atitikmenys – nustatymų dialogas („Duomenų šaltinis“ ir „CSV stulpelių atitikimas“ skyriai).
+- GMP laukas numatytai atpažįsta reikšmes „GMP“, „su GMP“ ir „GMP (su GMP)“, o tuščias hospitalizavimo stulpelis reiškia išrašytą pacientą.
 - Spalvų schema ir kampai – CSS kintamieji `:root` bloke (`index.html`).
 - Grafikai – Chart.js nustatymai `renderCharts()` funkcijoje (`index.html`).
 

--- a/index.html
+++ b/index.html
@@ -804,7 +804,7 @@
           <div class="settings-field">
             <label for="settingsTrueValues"><span>Reikšmės, laikomos „taip“</span></label>
             <input id="settingsTrueValues" name="csv.trueValues" type="text" placeholder="1,true,taip,yes">
-            <p class="settings-hint">Naudojama GMP laukui (ir kitiems „taip/ne“). Reikšmės automatiškai lyginamos be didžiųjų raidžių.</p>
+            <p class="settings-hint">Naudojama GMP laukui (ir kitiems „taip/ne“). Reikšmės automatiškai lyginamos be didžiųjų raidžių; numatytai atpažįstama „GMP“, „su GMP“, „GMP (su GMP)“, o „Ne GMP“ laikoma neigiamu atsakymu.</p>
           </div>
           <div class="settings-field">
             <label for="settingsHospitalizedValues"><span>Hospitalizavimo reikšmės</span></label>
@@ -1071,7 +1071,7 @@
         dayNight: 'Diena/naktis',
         gmp: 'GMP',
         department: 'Nukreiptas į padalinį',
-        trueValues: '1,true,taip,t,yes,y',
+        trueValues: '1,true,taip,t,yes,y,GMP,su GMP,GMP (su GMP)',
         hospitalizedValues: '',
         nightKeywords: 'nakt,night',
         dayKeywords: 'dien,ryt,vak,day',
@@ -2092,7 +2092,7 @@
         }
         if (record.arrival instanceof Date && record.discharge instanceof Date) {
           const duration = (record.discharge.getTime() - record.arrival.getTime()) / 3600000;
-          if (Number.isFinite(duration) && duration >= 0) {
+          if (Number.isFinite(duration) && duration >= 0 && duration <= 24) { // ignoruojame >24 val. buvimo laikus
             summary.totalTime += duration;
             summary.durations += 1;
           }


### PR DESCRIPTION
## Summary
- expand the default GMP “true” values to cover GMP, su GMP, and GMP (su GMP) entries while keeping Ne GMP negative
- clarify the GMP hint text in settings to document the new defaults
- ignore stays over 24 hours when calculating average times and document the changes in the README

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5225393948320a4cd8acb7928ea89