### PR TITLE
Remove default margins from chart cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,7 @@
       border-radius: 20px;
       border: 1px solid var(--color-border);
       padding: 24px;
+      margin: 0;
       box-shadow: var(--shadow-elevated);
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
## Summary
- remove the browser default margin from `.chart-card` figures so charts can use the full card width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54c9037c48320b8cf6d71d43b0849