### PR TITLE
Improve hero action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,63 +91,133 @@
       flex-wrap: wrap;
     }
 
-    button.icon-button {
+    .action-button {
       border: none;
-      border-radius: 50%;
-      width: 44px;
-      height: 44px;
+      border-radius: 999px;
+      padding: 10px 18px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
+      gap: 10px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      line-height: 1;
       cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, border-color 0.3s ease;
-      box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.7);
-      padding: 0;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+      position: relative;
+      min-height: 46px;
     }
 
-    button.icon-button svg {
-      width: 22px;
-      height: 22px;
-    }
-
-    button.icon-button:focus-visible {
+    .action-button:focus-visible {
       outline: 3px solid rgba(255, 255, 255, 0.6);
       outline-offset: 3px;
     }
 
-    button.refresh {
+    .action-button__icon,
+    .action-button__spinner {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+
+    .action-button__icon svg,
+    .action-button__spinner svg {
+      width: 22px;
+      height: 22px;
+    }
+
+    .action-button__label {
+      white-space: nowrap;
+    }
+
+    .action-button__shortcut {
+      font-size: 0.78rem;
+      font-weight: 500;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.08);
+      color: inherit;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+    }
+
+    .action-button__spinner {
+      position: absolute;
+      left: 18px;
+      top: 50%;
+      opacity: 0;
+      transform: translateY(-50%) scale(0.6);
+    }
+
+    .action-button__spinner svg {
+      animation: spin 0.9s linear infinite;
+    }
+
+    .action-button[data-loading="true"] .action-button__spinner {
+      opacity: 1;
+      transform: translateY(-50%) scale(1);
+    }
+
+    .action-button[data-loading="true"] .action-button__icon {
+      opacity: 0;
+      transform: scale(0.6);
+    }
+
+    .action-button[data-loading="true"] {
+      cursor: wait;
+    }
+
+    .action-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.8;
+      pointer-events: none;
+    }
+
+    .action-button--primary {
       background: #fff;
       color: var(--color-accent);
+      box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.7);
     }
 
-    button.refresh:hover,
-    button.refresh:focus-visible {
+    .action-button--primary:hover,
+    .action-button--primary:focus-visible {
       transform: translateY(-1px);
-      box-shadow: 0 15px 35px -20px rgba(15, 23, 42, 0.75);
-      background: rgba(255, 255, 255, 0.92);
+      box-shadow: 0 15px 35px -20px rgba(15, 23, 42, 0.78);
+      background: rgba(255, 255, 255, 0.94);
     }
 
-    button.refresh:active {
+    .action-button--primary:active {
       transform: translateY(0);
     }
 
-    button.settings-btn {
-      background: rgba(255, 255, 255, 0.1);
-      border: 1px solid rgba(255, 255, 255, 0.35);
+    .action-button--ghost {
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.3);
       color: #fff;
-      box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.8);
+      box-shadow: 0 10px 24px -20px rgba(15, 23, 42, 0.8);
     }
 
-    button.settings-btn:hover,
-    button.settings-btn:focus-visible {
+    .action-button--ghost:hover,
+    .action-button--ghost:focus-visible {
       transform: translateY(-1px);
-      background: rgba(255, 255, 255, 0.18);
+      background: rgba(255, 255, 255, 0.2);
       border-color: rgba(255, 255, 255, 0.65);
-      box-shadow: 0 16px 32px -20px rgba(15, 23, 42, 0.85);
+      box-shadow: 0 16px 32px -22px rgba(15, 23, 42, 0.85);
     }
 
-    button.settings-btn:active {
+    .action-button--ghost:active {
       transform: translateY(0);
+    }
+
+    @keyframes spin {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     .status {
@@ -702,6 +772,11 @@
         justify-content: flex-start;
       }
 
+      .action-button {
+        width: 100%;
+        justify-content: center;
+      }
+
       .section__header {
         align-items: flex-start;
       }
@@ -736,6 +811,17 @@
       }
     }
 
+    @media (max-width: 520px) {
+      .action-button {
+        gap: 8px;
+        padding: 10px 14px;
+      }
+
+      .action-button__shortcut {
+        display: none;
+      }
+    }
+
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after {
         animation-duration: 0.01ms !important;
@@ -755,15 +841,42 @@
       </div>
       <div class="hero__actions">
         <div class="hero__buttons">
-          <button id="openSettingsBtn" type="button" class="icon-button settings-btn" aria-haspopup="dialog" aria-label="Atidaryti nustatymus" title="Atidaryti nustatymus (Ctrl+,)">
-            <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
-              <path fill="currentColor" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm9-3.5a1 1 0 0 0-.63-.92l-1.47-.6a7.06 7.06 0 0 0-.36-.88l.65-1.44a1 1 0 0 0-.12-1.05l-1.5-1.94a1 1 0 0 0-1.02-.35l-1.53.36a6.85 6.85 0 0 0-.76-.45l-.26-1.55A1 1 0 0 0 12.7 2h-3.4a1 1 0 0 0-.99.83l-.26 1.55a6.85 6.85 0 0 0-.76.45l-1.53-.36a1 1 0 0 0-1.02.35L3.24 6.76a1 1 0 0 0-.12 1.05l.65 1.44c-.14.29-.26.58-.36.88l-1.47.6A1 1 0 0 0 2 12c0 .4.24.76.61.92l1.47.6c.1.3.22.59.36.88l-.65 1.44a1 1 0 0 0 .12 1.05l1.5 1.94a1 1 0 0 0 1.02.35l1.53-.36c.25.17.5.32.76.45l.26 1.55c.08.46.48.81.95.81h3.4c.47 0 .87-.35.95-.81l.26-1.55c.26-.13.51-.28.76-.45l1.53.36a1 1 0 0 0 1.02-.35l1.5-1.94a1 1 0 0 0 .12-1.05l-.65-1.44c.14-.29.26-.58.36-.88l1.47-.6c.39-.16.63-.52.63-.92Z"/>
-            </svg>
+          <button
+            id="openSettingsBtn"
+            type="button"
+            class="action-button action-button--ghost"
+            aria-haspopup="dialog"
+            aria-label="Atidaryti nustatymus"
+            title="Atidaryti nustatymus (Ctrl+,)"
+          >
+            <span class="action-button__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path fill="currentColor" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm9-3.5a1 1 0 0 0-.63-.92l-1.47-.6a7.06 7.06 0 0 0-.36-.88l.65-1.44a1 1 0 0 0-.12-1.05l-1.5-1.94a1 1 0 0 0-1.02-.35l-1.53.36a6.85 6.85 0 0 0-.76-.45l-.26-1.55A1 1 0 0 0 12.7 2h-3.4a1 1 0 0 0-.99.83l-.26 1.55a6.85 6.85 0 0 0-.76.45l-1.53-.36a1 1 0 0 0-1.02.35L3.24 6.76a1 1 0 0 0-.12 1.05l.65 1.44c-.14.29-.26.58-.36.88l-1.47.6A1 1 0 0 0 2 12c0 .4.24.76.61.92l1.47.6c.1.3.22.59.36.88l-.65 1.44a1 1 0 0 0 .12 1.05l1.5 1.94a1 1 0 0 0 1.02.35l1.53-.36c.25.17.5.32.76.45l.26 1.55c.08.46.48.81.95.81h3.4c.47 0 .87-.35.95-.81l.26-1.55c.26-.13.51-.28.76-.45l1.53.36a1 1 0 0 0 1.02-.35l1.5-1.94a1 1 0 0 0 .12-1.05l-.65-1.44c.14-.29.26-.58.36-.88l1.47-.6c.39-.16.63-.52.63-.92Z"/>
+              </svg>
+            </span>
+            <span id="settingsLabel" class="action-button__label">Nustatymai</span>
+            <span class="action-button__shortcut" aria-hidden="true">Ctrl+,</span>
           </button>
-          <button id="refreshBtn" type="button" class="icon-button refresh" aria-label="Perkrauti duomenis" title="Perkrauti duomenis (R)">
-            <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
-              <path fill="currentColor" d="M21 4v6h-6l2.24-2.24A6.97 6.97 0 0 0 5 12a7 7 0 0 0 12.59 4H19a1 1 0 1 1 0 2h-2a1 1 0 0 1-.8-.4A9 9 0 1 1 17.76 5.1L21 2v2Zm-9 5a1 1 0 0 1 .78.38l.07.1a1 1 0 0 1-.32 1.4l-.1.06A1 1 0 0 1 11 12a1 1 0 0 1-.78-.38l-.07-.1a1 1 0 0 1 .32-1.4l.1-.06A1 1 0 0 1 12 9Z"/>
-            </svg>
+          <button
+            id="refreshBtn"
+            type="button"
+            class="action-button action-button--primary"
+            data-loading="false"
+            aria-label="Perkrauti duomenis"
+            title="Perkrauti duomenis (R)"
+          >
+            <span class="action-button__spinner" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-dasharray="56" stroke-dashoffset="14"/>
+              </svg>
+            </span>
+            <span class="action-button__icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path fill="currentColor" d="M21 4v6h-6l2.24-2.24A6.97 6.97 0 0 0 5 12a7 7 0 0 0 12.59 4H19a1 1 0 1 1 0 2h-2a1 1 0 0 1-.8-.4A9 9 0 1 1 17.76 5.1L21 2v2Zm-9 5a1 1 0 0 1 .78.38l.07.1a1 1 0 0 1-.32 1.4l-.1.06A1 1 0 0 1 11 12a1 1 0 0 1-.78-.38l-.07-.1a1 1 0 0 1 .32-1.4l.1-.06A1 1 0 0 1 12 9Z"/>
+              </svg>
+            </span>
+            <span id="refreshLabel" class="action-button__label">Perkrauti duomenis</span>
+            <span class="action-button__shortcut" aria-hidden="true">R</span>
           </button>
         </div>
         <p id="status" class="status" role="status" aria-live="polite">Kraunama...</p>
@@ -1240,6 +1353,7 @@
       title: document.getElementById('pageTitle'),
       subtitle: document.getElementById('pageSubtitle'),
       refreshBtn: document.getElementById('refreshBtn'),
+      refreshLabel: document.getElementById('refreshLabel'),
       status: document.getElementById('status'),
       statusNote: document.getElementById('statusNote'),
       footerUpdated: document.getElementById('footerUpdated'),
@@ -1263,6 +1377,7 @@
       monthlyCaption: document.getElementById('monthlyCaption'),
       monthlyTable: document.getElementById('monthlyTable'),
       openSettingsBtn: document.getElementById('openSettingsBtn'),
+      settingsLabel: document.getElementById('settingsLabel'),
       settingsDialog: document.getElementById('settingsDialog'),
       settingsForm: document.getElementById('settingsForm'),
       resetSettingsBtn: document.getElementById('resetSettingsBtn'),
@@ -1771,6 +1886,7 @@
       },
       usingFallback: false,
       lastErrorMessage: '',
+      isLoading: false,
     };
 
     /**
@@ -1783,10 +1899,17 @@
         selectors.refreshBtn.setAttribute('aria-label', TEXT.refresh);
         selectors.refreshBtn.title = `${TEXT.refresh} (R)`;
       }
+      if (selectors.refreshLabel) {
+        selectors.refreshLabel.textContent = TEXT.refresh;
+      }
       if (selectors.openSettingsBtn) {
         selectors.openSettingsBtn.setAttribute('aria-label', TEXT.settings);
         selectors.openSettingsBtn.title = `${TEXT.settings} (Ctrl+,)`;
       }
+      if (selectors.settingsLabel) {
+        selectors.settingsLabel.textContent = TEXT.settings;
+      }
+      setRefreshButtonLoading(dashboardState.isLoading);
       selectors.kpiHeading.textContent = TEXT.kpis.title;
       selectors.kpiSubtitle.textContent = TEXT.kpis.subtitle;
       selectors.chartHeading.textContent = TEXT.charts.title;
@@ -1825,6 +1948,20 @@
       selectors.statusNote.textContent = message;
       selectors.statusNote.dataset.tone = tone;
       selectors.statusNote.removeAttribute('hidden');
+    }
+
+    function setRefreshButtonLoading(isLoading) {
+      if (!selectors.refreshBtn) {
+        return;
+      }
+      selectors.refreshBtn.dataset.loading = isLoading ? 'true' : 'false';
+      selectors.refreshBtn.disabled = Boolean(isLoading);
+      selectors.refreshBtn.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+      selectors.refreshBtn.setAttribute('aria-label', isLoading ? TEXT.status.loading : TEXT.refresh);
+      selectors.refreshBtn.title = isLoading ? TEXT.status.loading : `${TEXT.refresh} (R)`;
+      if (selectors.refreshLabel) {
+        selectors.refreshLabel.textContent = isLoading ? TEXT.status.loading : TEXT.refresh;
+      }
     }
 
     function setStatus(type, details = '') {
@@ -3055,6 +3192,11 @@
     }
 
     async function loadDashboard() {
+      if (dashboardState.isLoading) {
+        return;
+      }
+      dashboardState.isLoading = true;
+      setRefreshButtonLoading(true);
       try {
         setStatus('loading');
         const rawData = await fetchData();
@@ -3083,6 +3225,9 @@
         const friendlyMessage = describeError(error);
         dashboardState.lastErrorMessage = friendlyMessage;
         setStatus('error', friendlyMessage);
+      } finally {
+        dashboardState.isLoading = false;
+        setRefreshButtonLoading(false);
       }
     }
 
@@ -3134,9 +3279,24 @@
     }
 
     document.addEventListener('keydown', (event) => {
+      const target = event.target;
+      const isElement = target instanceof HTMLElement;
+      const isFormField = isElement
+        ? Boolean(target.closest('input, textarea, select, [contenteditable="true"]'))
+        : false;
+
       if ((event.ctrlKey || event.metaKey) && event.key === ',') {
         event.preventDefault();
         openSettingsDialog();
+        return;
+      }
+
+      if (!event.ctrlKey && !event.metaKey && !event.altKey && typeof event.key === 'string' && event.key.toLowerCase() === 'r') {
+        if (isFormField) {
+          return;
+        }
+        event.preventDefault();
+        loadDashboard();
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- restyle the hero settings and refresh controls with labeled pill buttons and shortcut hints
- add a refresh loading state with spinner feedback, button disabling, and reuse-friendly text updates
- block duplicate fetches and introduce the `R` keyboard shortcut to trigger data reloads

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68d55d63629c8320bc5d819e1d721ace