### PR TITLE
Remove weekend label from recent table

### DIFF
--- a/index.html
+++ b/index.html
@@ -3405,11 +3405,8 @@
             row.classList.add('recent-table-row--weekend');
             row.dataset.weekend = 'true';
           }
-          const weekendBadge = weekend
-            ? '<span class="table-flag table-flag--weekend" aria-hidden="true">Savaitgalis</span><span class="sr-only"> (savaitgalis)</span>'
-            : '';
           row.innerHTML = `
-            <td>${displayDate}${weekendBadge}</td>
+            <td>${displayDate}</td>
             <td>${numberFormatter.format(total)}</td>
             <td>${decimalFormatter.format(entry.durations ? entry.totalTime / entry.durations : 0)}</td>
             <td>${formatValueWithShare(entry.night, total)}</td>


### PR DESCRIPTION
## Summary
- remove the explicit "Savaitgalis" badge from the "Paskutinės 7 dienos" table
- keep weekend rows highlighted only via the existing background and text color styling

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5aab44c5c8320bb557ddd283abed7