### PR TITLE
Improve dark theme filter label contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,10 @@
       color: #e2e8f0;
     }
 
+    body[data-theme="dark"] .kpi-filter span {
+      color: var(--color-text);
+    }
+
     .status {
       margin-top: 8px;
       font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- ensure KPI filtrų antraštės tamsioje temoje paveldi šviesesnę teksto spalvą, kad būtų geresnis kontrastas

## Testing
- nebuvo reikalinga

------
https://chatgpt.com/codex/tasks/task_e_68d6205265a483209982f0f281f76181