### PR TITLE
Fix primary data source URL typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,7 +1658,7 @@
     const DEFAULT_KPI_WINDOW_DAYS = 365;
     const DEFAULT_SETTINGS = {
       dataSource: {
-        url: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vS8xfS3FxpD5pT6rm-ClSf9DjV3usXjvJG4uKj7aC3_QtThtXidQZaN0ZQe9SEM0XB94XeLshwwLUSW/pub?gid=706041848&single=true&output=csv',
+        url: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vS8xfS3FxpD5pT6rm-ClSf9DjV3usXjvJG4uKj7aC3_QtThtXidQZaN0ZQe9SEMOXB94XeLshwwLUSW/pub?gid=706041848&single=true&output=csv',
         useFallback: true,
         fallbackCsv: DEFAULT_DEMO_CSV,
       },


### PR DESCRIPTION
## Summary
- correct the Google Sheets CSV URL used in the default data source configuration
- verified that the dashboard loads live data without needing a manual URL override

## Testing
- browser_container.run_playwright_script (smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68d62c655aa88320bfb4fba6200f49b0