### PR TITLE
Fix dark theme select option contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,12 @@
       --shadow-elevated: 0 16px 30px -18px rgba(15, 23, 42, 0.75);
     }
 
+    body[data-theme="dark"] select option,
+    body[data-theme="dark"] select optgroup {
+      background: var(--color-surface);
+      color: var(--color-text);
+    }
+
     .container {
       width: min(1220px, 92vw);
       margin: 0 auto;


### PR DESCRIPTION
## Summary
- ensure native select options keep readable foreground/background colors in dark theme

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68d69db8fe148320a0a01368310cd650