### PR TITLE
Improve compare toggle active styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1171,11 +1171,33 @@
       color: var(--color-accent);
     }
 
+    .btn-secondary[aria-pressed="true"] {
+      background: var(--color-accent);
+      border-color: var(--color-accent);
+      color: #fff;
+      font-weight: 600;
+      box-shadow: 0 12px 30px -18px rgba(15, 23, 42, 0.4);
+    }
+
+    body[data-theme="dark"] .btn-secondary[aria-pressed="true"] {
+      box-shadow: 0 12px 30px -18px rgba(15, 23, 42, 0.65);
+    }
+
     .btn-secondary:hover,
     .btn-secondary:focus-visible {
       transform: translateY(-1px);
       background: rgba(37, 99, 235, 0.08);
       border-color: rgba(37, 99, 235, 0.55);
+      outline: none;
+    }
+
+    .btn-secondary[aria-pressed="true"]:hover,
+    .btn-secondary[aria-pressed="true"]:focus-visible {
+      background: var(--color-accent);
+      border-color: var(--color-accent);
+      color: #fff;
+      transform: translateY(-1px);
+      box-shadow: 0 16px 36px -18px rgba(15, 23, 42, 0.5);
       outline: none;
     }
 


### PR DESCRIPTION
## Summary
- add dedicated active-state styling for secondary buttons tied to aria-pressed to improve visual feedback
- ensure hover and focus-visible states preserve contrast for the active toggle across light and dark themes

## Testing
- browser_container Playwright scenario toggling compare mode and theme

------
https://chatgpt.com/codex/tasks/task_e_68d858e270fc8320a29b9eb19db05e69