### PR TITLE
Aggregate feedback data for monthly summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,6 +354,59 @@
       color: var(--color-text-muted);
     }
 
+    .section__description {
+      margin: 8px 0 0;
+      font-size: 0.92rem;
+      color: var(--color-text-muted);
+      max-width: 720px;
+    }
+
+    .feedback-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+      margin-bottom: 20px;
+    }
+
+    .feedback-card {
+      position: relative;
+      padding: 18px 20px;
+      border-radius: 18px;
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      box-shadow: var(--shadow-elevated);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .feedback-card__title {
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--color-text-muted);
+      margin: 0;
+    }
+
+    .feedback-card__value {
+      font-size: 2rem;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .feedback-card__meta {
+      font-size: 0.9rem;
+      color: var(--color-text-muted);
+      margin: 0;
+    }
+
+    .feedback-empty {
+      padding: 18px;
+      text-align: center;
+      color: var(--color-text-muted);
+    }
+
     .kpi-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -1470,6 +1523,35 @@
         </table>
       </div>
     </section>
+
+    <section class="section section--compact" aria-labelledby="feedbackHeading" data-section="feedback">
+      <div class="section__header">
+        <div>
+          <h2 id="feedbackHeading" class="section__title">Pacientų atsiliepimai</h2>
+          <p id="feedbackSubtitle" class="section__subtitle">Apibendrinti apklausos rezultatai</p>
+          <p id="feedbackDescription" class="section__description">Kortelės rodo bendras įžvalgas, lentelė – mėnesines suvestines.</p>
+        </div>
+      </div>
+      <div id="feedbackCards" class="feedback-cards" role="list"></div>
+      <div class="table-wrapper" role="region" aria-live="polite" aria-labelledby="feedbackHeading">
+        <table aria-describedby="feedbackSubtitle feedbackDescription">
+          <caption id="feedbackCaption" class="sr-only">Mėnesio atsiliepimų suvestinė pagal apklausos vertinimus.</caption>
+          <thead>
+            <tr>
+              <th scope="col" id="feedbackColumnMonth">Mėnuo</th>
+              <th scope="col" id="feedbackColumnResponses">Atsakymai</th>
+              <th scope="col" id="feedbackColumnOverall">Bendra patirtis (vid.)</th>
+              <th scope="col" id="feedbackColumnDoctors">Gydytojų darbas (vid.)</th>
+              <th scope="col" id="feedbackColumnNurses">Slaugytojų darbas (vid.)</th>
+              <th scope="col" id="feedbackColumnAides">Padėjėjų darbas (vid.)</th>
+              <th scope="col" id="feedbackColumnWaiting">Laukimo vertinimas (vid.)</th>
+              <th scope="col" id="feedbackColumnContact">Bendravo su padėjėjais</th>
+            </tr>
+          </thead>
+          <tbody id="feedbackTable"></tbody>
+        </table>
+      </div>
+    </section>
   </main>
 
   <dialog id="settingsDialog" aria-labelledby="settingsTitle">
@@ -1494,6 +1576,24 @@
             <label for="settingsFallbackCsv"><span>Demonstracinis CSV</span></label>
             <textarea id="settingsFallbackCsv" name="dataSource.fallbackCsv" spellcheck="false"></textarea>
             <p class="settings-hint">Palikite tuščią, jei nereikia rezervinio rinkinio. Galite įklijuoti savo CSV iškarpą.</p>
+          </div>
+        </section>
+
+        <section class="settings-section" aria-labelledby="settingsFeedbackDataTitle">
+          <h3 id="settingsFeedbackDataTitle">Atsiliepimų duomenys</h3>
+          <div class="settings-field">
+            <label for="settingsFeedbackUrl"><span>CSV nuoroda (atsiliepimai)</span></label>
+            <input id="settingsFeedbackUrl" name="dataSource.feedback.url" type="url" placeholder="https://docs.google.com/.../output=csv" autocomplete="off">
+            <p class="settings-hint">Naudokite atskirą publikavimo nuorodą atsiliepimų rinkiniui arba palikite tuščią, jei naudosite tik demonstracinius komentarus.</p>
+          </div>
+          <label class="settings-checkbox" for="settingsFeedbackUseFallback">
+            <input id="settingsFeedbackUseFallback" name="dataSource.feedback.useFallback" type="checkbox">
+            <span>Naudoti demonstracinius atsiliepimus, jei nepavyksta pasiekti nuotolinio šaltinio.</span>
+          </label>
+          <div class="settings-field">
+            <label for="settingsFeedbackFallbackCsv"><span>Demonstracinis CSV (atsiliepimai)</span></label>
+            <textarea id="settingsFeedbackFallbackCsv" name="dataSource.feedback.fallbackCsv" spellcheck="false"></textarea>
+            <p class="settings-hint">CSV turi turėti stulpelius: data, įvertinimas, komentaro tekstas, kanalas ir (pasirinktinai) nuotaikos reikšmė.</p>
           </div>
         </section>
 
@@ -1615,6 +1715,20 @@
               <input id="settingsMonthlySubtitle" name="output.monthlySubtitle" type="text">
             </div>
           </div>
+          <div class="settings-inline">
+            <div class="settings-field">
+              <label for="settingsFeedbackTitle"><span>„Atsiliepimų“ pavadinimas</span></label>
+              <input id="settingsFeedbackTitle" name="output.feedbackTitle" type="text">
+            </div>
+            <div class="settings-field">
+              <label for="settingsFeedbackSubtitle"><span>„Atsiliepimų“ paantraštė</span></label>
+              <input id="settingsFeedbackSubtitle" name="output.feedbackSubtitle" type="text">
+            </div>
+          </div>
+          <div class="settings-field">
+            <label for="settingsFeedbackDescription"><span>„Atsiliepimų“ aprašymas</span></label>
+            <input id="settingsFeedbackDescription" name="output.feedbackDescription" type="text">
+          </div>
           <div class="settings-field">
             <label for="settingsFooterSource"><span>Apatinės eilutės tekstas</span></label>
             <input id="settingsFooterSource" name="output.footerSource" type="text" placeholder="Duomenys: ...">
@@ -1626,6 +1740,10 @@
           <label class="settings-checkbox" for="settingsShowMonthly">
             <input id="settingsShowMonthly" name="output.showMonthly" type="checkbox">
             <span>Rodyti „Mėnesinė suvestinė“ lentelę.</span>
+          </label>
+          <label class="settings-checkbox" for="settingsShowFeedback">
+            <input id="settingsShowFeedback" name="output.showFeedback" type="checkbox">
+            <span>Rodyti „Atsiliepimų“ sekciją.</span>
           </label>
         </section>
       </div>
@@ -1700,6 +1818,12 @@
 2024-02-08T05:50:00+02:00,2024-02-08T09:15:00+02:00,Rytas,TAIP,
 2024-02-08T19:30:00+02:00,2024-02-08T23:05:00+02:00,Vakare,NE,
 2024-02-09T23:10:00+02:00,2024-02-10T02:20:00+02:00,Naktis,TAIP,Traumatologija`;
+    const DEFAULT_FEEDBACK_CSV = `Timestamp,Kas pildo formą?,Kaip vertinate savo bendrą patirtį mūsų skyriuje?,Kaip vertinate gydytojų darbą,Kaip vertinate slaugytojų darbą ?,Ar bendravote su slaugytojų padėjėjais?,Kaip vertinate slaugytojų padėjėjų darbą,Kaip vertinate laukimo laiką skyriuje?
+2024-02-01T09:12:00+02:00,Pacientas,9,9,10,Taip,10,8
+2024-02-02T18:40:00+02:00,Artimasis,7,8,7,Ne,,6
+2024-02-03T12:05:00+02:00,Pacientas,10,10,10,Taip,10,9
+2024-02-04T22:20:00+02:00,Artimasis,6,6,5,Taip,6,4
+2024-02-05T08:55:00+02:00,Pacientas,8,9,8,Ne,,7`;
     /**
      * Konfigūracija tekstams ir greitiems pakeitimams (LT numatytasis, lengva išplėsti EN).
      */
@@ -1809,6 +1933,89 @@
         caption: 'Mėnesių pacientų suvestinė: sumos ir vidurkiai.',
         empty: 'Duomenų lentelė bus parodyta užkrovus failą.',
       },
+      feedback: {
+        title: 'Pacientų atsiliepimai',
+        subtitle: 'Apibendrinti apklausos rezultatai.',
+        description: 'Kortelės rodo bendras įžvalgas, lentelė – mėnesines suvestines.',
+        empty: 'Kol kas nėra apibendrintų atsiliepimų.',
+        cards: [
+          {
+            key: 'overallAverage',
+            title: 'Bendra patirtis',
+            description: 'Vidurkis (1–10) pagal bendros patirties klausimą.',
+            empty: 'Nėra vertinimų.',
+            format: 'decimal',
+            countKey: 'overallCount',
+          },
+          {
+            key: 'doctorsAverage',
+            title: 'Gydytojų darbas',
+            description: 'Vidurkis (1–10) apie gydytojų darbą.',
+            empty: 'Nėra vertinimų.',
+            format: 'decimal',
+            countKey: 'doctorsCount',
+          },
+          {
+            key: 'nursesAverage',
+            title: 'Slaugytojų darbas',
+            description: 'Vidurkis (1–10) apie slaugytojų darbą.',
+            empty: 'Nėra vertinimų.',
+            format: 'decimal',
+            countKey: 'nursesCount',
+          },
+          {
+            key: 'aidesAverage',
+            title: 'Slaugytojų padėjėjų darbas',
+            description: 'Atsiliepimai iš pacientų, bendravusių su padėjėjais.',
+            empty: 'Nėra duomenų.',
+            format: 'decimal',
+            countKey: 'aidesResponses',
+          },
+          {
+            key: 'waitingAverage',
+            title: 'Laukimo laikas',
+            description: 'Vidutinis laukimo vertinimas (1–10).',
+            empty: 'Nėra vertinimų.',
+            format: 'decimal',
+            countKey: 'waitingCount',
+          },
+          {
+            key: 'contactShare',
+            title: 'Bendravo su padėjėjais',
+            description: 'Dalies, pasirinkusių „Taip“, procentas.',
+            empty: 'Nėra duomenų.',
+            format: 'percent',
+            countKey: 'contactResponses',
+          },
+          {
+            key: 'totalResponses',
+            title: 'Užpildytos formos',
+            description: 'Bendras gautų atsakymų skaičius.',
+            empty: '0',
+            format: 'integer',
+          },
+        ],
+        table: {
+          caption: 'Mėnesio atsiliepimų suvestinė pagal apklausos vertinimus.',
+          empty: 'Dar neturime mėnesinių atsiliepimų suvestinių.',
+          headers: {
+            month: 'Mėnuo',
+            responses: 'Atsakymai',
+            overall: 'Bendra patirtis (vid.)',
+            doctors: 'Gydytojų darbas (vid.)',
+            nurses: 'Slaugytojų darbas (vid.)',
+            aides: 'Padėjėjų darbas (vid.)',
+            waiting: 'Laukimo vertinimas (vid.)',
+            contact: 'Bendravo su padėjėjais',
+          },
+          placeholder: '—',
+        },
+        status: {
+          fallback: (reason) => `Atsiliepimai rodomi iš demonstracinio šaltinio: ${reason}`,
+          error: (reason) => `Atsiliepimų nepavyko įkelti: ${reason}`,
+          missingUrl: 'Nenurodytas atsiliepimų duomenų URL.',
+        },
+      },
       compare: {
         toggle: 'Palyginti',
         active: 'Uždaryti palyginimą',
@@ -1833,6 +2040,11 @@
         url: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vS8xfS3FxpD5pT6rm-ClSf9DjV3usXjvJG4uKj7aC3_QtThtXidQZaN0ZQe9SEMOXB94XeLshwwLUSW/pub?gid=706041848&single=true&output=csv',
         useFallback: true,
         fallbackCsv: DEFAULT_DEMO_CSV,
+        feedback: {
+          url: 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTr4ghdkkUJw5pYjb7nTDgoGdaTIUjLT7bD_8q05QyBNR4Z-tTVqhWMvXGemJUIneXyyUF_8-O-EftK/pub?gid=369777093&single=true&output=csv',
+          useFallback: true,
+          fallbackCsv: DEFAULT_FEEDBACK_CSV,
+        },
       },
       csv: {
         arrival: 'Atvykimo data',
@@ -1862,9 +2074,13 @@
         recentSubtitle: TEXT.recent.subtitle,
         monthlyTitle: TEXT.monthly.title,
         monthlySubtitle: TEXT.monthly.subtitle,
+        feedbackTitle: TEXT.feedback.title,
+        feedbackSubtitle: TEXT.feedback.subtitle,
+        feedbackDescription: TEXT.feedback.description,
         footerSource: DEFAULT_FOOTER_SOURCE,
         showRecent: true,
         showMonthly: true,
+        showFeedback: true,
       },
     };
 
@@ -1952,6 +2168,20 @@
       monthlySubtitle: document.getElementById('monthlySubtitle'),
       monthlyCaption: document.getElementById('monthlyCaption'),
       monthlyTable: document.getElementById('monthlyTable'),
+      feedbackHeading: document.getElementById('feedbackHeading'),
+      feedbackSubtitle: document.getElementById('feedbackSubtitle'),
+      feedbackDescription: document.getElementById('feedbackDescription'),
+      feedbackCaption: document.getElementById('feedbackCaption'),
+      feedbackCards: document.getElementById('feedbackCards'),
+      feedbackTable: document.getElementById('feedbackTable'),
+      feedbackColumnMonth: document.getElementById('feedbackColumnMonth'),
+      feedbackColumnResponses: document.getElementById('feedbackColumnResponses'),
+      feedbackColumnOverall: document.getElementById('feedbackColumnOverall'),
+      feedbackColumnDoctors: document.getElementById('feedbackColumnDoctors'),
+      feedbackColumnNurses: document.getElementById('feedbackColumnNurses'),
+      feedbackColumnAides: document.getElementById('feedbackColumnAides'),
+      feedbackColumnWaiting: document.getElementById('feedbackColumnWaiting'),
+      feedbackColumnContact: document.getElementById('feedbackColumnContact'),
       openSettingsBtn: document.getElementById('openSettingsBtn'),
       themeToggleBtn: document.getElementById('themeToggleBtn'),
       settingsDialog: document.getElementById('settingsDialog'),
@@ -1960,6 +2190,7 @@
       cancelSettingsBtn: document.getElementById('cancelSettingsBtn'),
       recentSection: document.querySelector('[data-section="recent"]'),
       monthlySection: document.querySelector('[data-section="monthly"]'),
+      feedbackSection: document.querySelector('[data-section="feedback"]'),
       kpiControls: document.querySelector('.kpi-controls'),
       kpiFiltersForm: document.getElementById('kpiFiltersForm'),
       kpiWindow: document.getElementById('kpiWindow'),
@@ -2020,6 +2251,14 @@
       merged.dataSource.fallbackCsv = typeof merged.dataSource.fallbackCsv === 'string'
         ? merged.dataSource.fallbackCsv
         : DEFAULT_SETTINGS.dataSource.fallbackCsv;
+      if (!merged.dataSource.feedback || typeof merged.dataSource.feedback !== 'object') {
+        merged.dataSource.feedback = cloneSettings(DEFAULT_SETTINGS.dataSource.feedback);
+      }
+      merged.dataSource.feedback.url = (merged.dataSource.feedback.url ?? '').trim();
+      merged.dataSource.feedback.useFallback = Boolean(merged.dataSource.feedback.useFallback);
+      merged.dataSource.feedback.fallbackCsv = typeof merged.dataSource.feedback.fallbackCsv === 'string'
+        ? merged.dataSource.feedback.fallbackCsv
+        : DEFAULT_SETTINGS.dataSource.feedback.fallbackCsv;
 
       ['arrival', 'discharge', 'dayNight', 'gmp', 'department', 'trueValues', 'hospitalizedValues', 'nightKeywords', 'dayKeywords']
         .forEach((key) => {
@@ -2072,9 +2311,13 @@
       }
       merged.output.monthlyTitle = merged.output.monthlyTitle != null ? String(merged.output.monthlyTitle) : DEFAULT_SETTINGS.output.monthlyTitle;
       merged.output.monthlySubtitle = merged.output.monthlySubtitle != null ? String(merged.output.monthlySubtitle) : DEFAULT_SETTINGS.output.monthlySubtitle;
+      merged.output.feedbackTitle = merged.output.feedbackTitle != null ? String(merged.output.feedbackTitle) : DEFAULT_SETTINGS.output.feedbackTitle;
+      merged.output.feedbackSubtitle = merged.output.feedbackSubtitle != null ? String(merged.output.feedbackSubtitle) : DEFAULT_SETTINGS.output.feedbackSubtitle;
+      merged.output.feedbackDescription = merged.output.feedbackDescription != null ? String(merged.output.feedbackDescription) : DEFAULT_SETTINGS.output.feedbackDescription;
       merged.output.footerSource = merged.output.footerSource != null ? String(merged.output.footerSource) : DEFAULT_SETTINGS.output.footerSource;
       merged.output.showRecent = Boolean(merged.output.showRecent);
       merged.output.showMonthly = Boolean(merged.output.showMonthly);
+      merged.output.showFeedback = Boolean(merged.output.showFeedback);
 
       return merged;
     }
@@ -2112,6 +2355,9 @@
       TEXT.recent.subtitle = settings.output.recentSubtitle || DEFAULT_SETTINGS.output.recentSubtitle;
       TEXT.monthly.title = settings.output.monthlyTitle || DEFAULT_SETTINGS.output.monthlyTitle;
       TEXT.monthly.subtitle = settings.output.monthlySubtitle || DEFAULT_SETTINGS.output.monthlySubtitle;
+      TEXT.feedback.title = settings.output.feedbackTitle || DEFAULT_SETTINGS.output.feedbackTitle;
+      TEXT.feedback.subtitle = settings.output.feedbackSubtitle || DEFAULT_SETTINGS.output.feedbackSubtitle;
+      TEXT.feedback.description = settings.output.feedbackDescription || DEFAULT_SETTINGS.output.feedbackDescription;
     }
 
     function applyFooterSource() {
@@ -2136,6 +2382,7 @@
     function applySectionVisibility() {
       toggleSectionVisibility(selectors.recentSection, settings.output.showRecent);
       toggleSectionVisibility(selectors.monthlySection, settings.output.showMonthly);
+      toggleSectionVisibility(selectors.feedbackSection, settings.output.showFeedback);
     }
 
     function parseCandidateList(value, fallback = '') {
@@ -2276,6 +2523,9 @@
       assign('dataSource.url', settings.dataSource.url);
       assign('dataSource.useFallback', settings.dataSource.useFallback);
       assign('dataSource.fallbackCsv', settings.dataSource.fallbackCsv);
+      assign('dataSource.feedback.url', settings.dataSource.feedback?.url);
+      assign('dataSource.feedback.useFallback', settings.dataSource.feedback?.useFallback);
+      assign('dataSource.feedback.fallbackCsv', settings.dataSource.feedback?.fallbackCsv);
 
       assign('csv.arrival', settings.csv.arrival);
       assign('csv.discharge', settings.csv.discharge);
@@ -2302,9 +2552,13 @@
       assign('output.recentSubtitle', settings.output.recentSubtitle);
       assign('output.monthlyTitle', settings.output.monthlyTitle);
       assign('output.monthlySubtitle', settings.output.monthlySubtitle);
+      assign('output.feedbackTitle', settings.output.feedbackTitle);
+      assign('output.feedbackSubtitle', settings.output.feedbackSubtitle);
+      assign('output.feedbackDescription', settings.output.feedbackDescription);
       assign('output.footerSource', settings.output.footerSource);
       assign('output.showRecent', settings.output.showRecent);
       assign('output.showMonthly', settings.output.showMonthly);
+      assign('output.showFeedback', settings.output.showFeedback);
     }
 
     function extractSettingsFromForm(form) {
@@ -2313,6 +2567,11 @@
           url: '',
           useFallback: false,
           fallbackCsv: '',
+          feedback: {
+            url: '',
+            useFallback: false,
+            fallbackCsv: '',
+          },
         },
         csv: {
           arrival: '',
@@ -2342,9 +2601,13 @@
           recentSubtitle: '',
           monthlyTitle: '',
           monthlySubtitle: '',
+          feedbackTitle: '',
+          feedbackSubtitle: '',
+          feedbackDescription: '',
           footerSource: '',
           showRecent: false,
           showMonthly: false,
+          showFeedback: false,
         },
       };
 
@@ -2367,6 +2630,9 @@
       result.dataSource.url = readText('dataSource.url').trim();
       result.dataSource.useFallback = readCheckbox('dataSource.useFallback');
       result.dataSource.fallbackCsv = readText('dataSource.fallbackCsv').trim();
+      result.dataSource.feedback.url = readText('dataSource.feedback.url').trim();
+      result.dataSource.feedback.useFallback = readCheckbox('dataSource.feedback.useFallback');
+      result.dataSource.feedback.fallbackCsv = readText('dataSource.feedback.fallbackCsv').trim();
 
       result.csv.arrival = readText('csv.arrival').trim();
       result.csv.discharge = readText('csv.discharge').trim();
@@ -2393,9 +2659,13 @@
       result.output.recentSubtitle = readText('output.recentSubtitle').trim();
       result.output.monthlyTitle = readText('output.monthlyTitle').trim();
       result.output.monthlySubtitle = readText('output.monthlySubtitle').trim();
+      result.output.feedbackTitle = readText('output.feedbackTitle').trim();
+      result.output.feedbackSubtitle = readText('output.feedbackSubtitle').trim();
+      result.output.feedbackDescription = readText('output.feedbackDescription').trim();
       result.output.footerSource = readText('output.footerSource').trim();
       result.output.showRecent = readCheckbox('output.showRecent');
       result.output.showMonthly = readCheckbox('output.showMonthly');
+      result.output.showFeedback = readCheckbox('output.showFeedback');
 
       return result;
     }
@@ -2510,6 +2780,12 @@
         records: [],
         daily: [],
       },
+      feedback: {
+        summary: null,
+        monthly: [],
+        usingFallback: false,
+        lastErrorMessage: '',
+      },
     };
 
     /**
@@ -2550,6 +2826,38 @@
       selectors.monthlyHeading.textContent = TEXT.monthly.title;
       selectors.monthlySubtitle.textContent = TEXT.monthly.subtitle;
       selectors.monthlyCaption.textContent = TEXT.monthly.caption;
+      selectors.feedbackHeading.textContent = TEXT.feedback.title;
+      selectors.feedbackSubtitle.textContent = TEXT.feedback.subtitle;
+      if (selectors.feedbackDescription) {
+        selectors.feedbackDescription.textContent = TEXT.feedback.description;
+      }
+      if (selectors.feedbackCaption) {
+        selectors.feedbackCaption.textContent = TEXT.feedback.table.caption;
+      }
+      if (selectors.feedbackColumnMonth) {
+        selectors.feedbackColumnMonth.textContent = TEXT.feedback.table.headers.month;
+      }
+      if (selectors.feedbackColumnResponses) {
+        selectors.feedbackColumnResponses.textContent = TEXT.feedback.table.headers.responses;
+      }
+      if (selectors.feedbackColumnOverall) {
+        selectors.feedbackColumnOverall.textContent = TEXT.feedback.table.headers.overall;
+      }
+      if (selectors.feedbackColumnDoctors) {
+        selectors.feedbackColumnDoctors.textContent = TEXT.feedback.table.headers.doctors;
+      }
+      if (selectors.feedbackColumnNurses) {
+        selectors.feedbackColumnNurses.textContent = TEXT.feedback.table.headers.nurses;
+      }
+      if (selectors.feedbackColumnAides) {
+        selectors.feedbackColumnAides.textContent = TEXT.feedback.table.headers.aides;
+      }
+      if (selectors.feedbackColumnWaiting) {
+        selectors.feedbackColumnWaiting.textContent = TEXT.feedback.table.headers.waiting;
+      }
+      if (selectors.feedbackColumnContact) {
+        selectors.feedbackColumnContact.textContent = TEXT.feedback.table.headers.contact;
+      }
       if (selectors.compareToggle) {
         selectors.compareToggle.textContent = TEXT.compare.toggle;
       }
@@ -2749,6 +3057,20 @@
         selectors.status.textContent = details || TEXT.status.success(formatted);
         selectors.footerUpdated.textContent = TEXT.footer(formatted);
         hideStatusNote();
+      }
+    }
+
+    function applyFeedbackStatusNote() {
+      if (dashboardState.usingFallback || !settings.output.showFeedback) {
+        return;
+      }
+      if (dashboardState.feedback.usingFallback) {
+        const reason = dashboardState.feedback.lastErrorMessage || TEXT.status.error;
+        showStatusNote(TEXT.feedback.status.fallback(reason), 'warning');
+        return;
+      }
+      if (dashboardState.feedback.lastErrorMessage) {
+        showStatusNote(TEXT.feedback.status.error(dashboardState.feedback.lastErrorMessage), 'warning');
       }
     }
 
@@ -3157,6 +3479,210 @@
       }
     }
 
+    const FEEDBACK_HEADER_CANDIDATES = {
+      date: 'timestamp,gauta,data,received,created,submitted,laikas',
+      respondent: 'kas pildo formą?,kas pildo formą,kas pildo forma,respondentas,role,dalyvis,tipas',
+      overall: 'kaip vertinate savo bendrą patirtį mūsų skyriuje?,*bendr* patirt*,overall,general experience,experience rating',
+      doctors: 'kaip vertinate gydytojų darbą,*gydytojų darb*,gydytoju darba,gydytojų vertinimas,physician,doctor rating',
+      nurses: 'kaip vertinate slaugytojų darbą ?,kaip vertinate slaugytojų darbą,*slaugytojų darb*,slaugytoju darba,slaugytojų vertinimas,nurse rating',
+      aidesContact: 'ar bendravote su slaugytojų padėjėjais?,ar bendravote su slaugytojų padėjėjais,ar bendravote su slaugytoju padejejais,ar bendravote su padėjėjais,contact with aides',
+      aides: 'kaip vertinate slaugytojų padėjėjų darbą,*padėjėjų darb*,slaugytoju padejeju darba,padėjėjų vertinimas,aide rating',
+      waiting: 'kaip vertinate laukimo laiką skyriuje?,*laukimo laik*,wait time,laukimo vertinimas',
+    };
+
+    const FEEDBACK_CONTACT_YES = 'taip,yes,yeah,1,true';
+    const FEEDBACK_CONTACT_NO = 'ne,no,0,false';
+
+    function resolveFeedbackColumn(headerNormalized, candidateList) {
+      const candidates = parseCandidateList(candidateList, candidateList);
+      for (const candidate of candidates) {
+        const normalizedCandidate = candidate.toLowerCase();
+        const match = headerNormalized.find((column) => matchesWildcard(column.normalized, normalizedCandidate));
+        if (match) {
+          return match.index;
+        }
+      }
+      return -1;
+    }
+
+    function parseFeedbackRatingCell(value) {
+      if (value == null) {
+        return null;
+      }
+      const text = String(value).trim();
+      if (!text) {
+        return null;
+      }
+      const normalized = text.replace(',', '.');
+      const direct = Number.parseFloat(normalized);
+      if (Number.isFinite(direct)) {
+        return direct;
+      }
+      const match = normalized.match(/(-?\d+(?:\.\d+)?)/);
+      if (match) {
+        const fallback = Number.parseFloat(match[1]);
+        return Number.isFinite(fallback) ? fallback : null;
+      }
+      return null;
+    }
+
+    function parseFeedbackContactValue(value, yesCandidates, noCandidates) {
+      if (value == null) {
+        return null;
+      }
+      const text = String(value).trim();
+      if (!text) {
+        return null;
+      }
+      const normalized = text.toLowerCase();
+      if (yesCandidates.some((candidate) => matchesWildcard(normalized, candidate))) {
+        return true;
+      }
+      if (noCandidates.some((candidate) => matchesWildcard(normalized, candidate))) {
+        return false;
+      }
+      return null;
+    }
+
+    function transformFeedbackCsv(text) {
+      if (typeof text !== 'string' || !text.trim()) {
+        return [];
+      }
+      const { rows } = parseCsv(text);
+      if (!rows.length) {
+        return [];
+      }
+      const header = rows[0].map((cell) => String(cell ?? '').trim());
+      const headerNormalized = header.map((column, index) => ({
+        original: column,
+        normalized: column.toLowerCase(),
+        index,
+      }));
+
+      const indices = {
+        date: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.date),
+        respondent: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.respondent),
+        overall: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.overall),
+        doctors: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.doctors),
+        nurses: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.nurses),
+        aidesContact: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.aidesContact),
+        aides: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.aides),
+        waiting: resolveFeedbackColumn(headerNormalized, FEEDBACK_HEADER_CANDIDATES.waiting),
+      };
+
+      const yesCandidates = parseCandidateList(FEEDBACK_CONTACT_YES, FEEDBACK_CONTACT_YES)
+        .map((token) => token.toLowerCase());
+      const noCandidates = parseCandidateList(FEEDBACK_CONTACT_NO, FEEDBACK_CONTACT_NO)
+        .map((token) => token.toLowerCase());
+
+      const rowsWithoutHeader = rows.slice(1).filter((row) => row.some((cell) => (cell ?? '').trim().length > 0));
+      return rowsWithoutHeader
+        .map((columns) => {
+          const rawDate = indices.date >= 0 ? columns[indices.date] : '';
+          const parsedDate = parseDate(rawDate);
+          const dateValue = parsedDate instanceof Date && !Number.isNaN(parsedDate.getTime()) ? parsedDate : null;
+
+          const respondent = indices.respondent >= 0
+            ? String(columns[indices.respondent] ?? '').trim()
+            : '';
+
+          const overallRating = indices.overall >= 0
+            ? parseFeedbackRatingCell(columns[indices.overall])
+            : null;
+          const doctorsRating = indices.doctors >= 0
+            ? parseFeedbackRatingCell(columns[indices.doctors])
+            : null;
+          const nursesRating = indices.nurses >= 0
+            ? parseFeedbackRatingCell(columns[indices.nurses])
+            : null;
+          const aidesContact = indices.aidesContact >= 0
+            ? parseFeedbackContactValue(columns[indices.aidesContact], yesCandidates, noCandidates)
+            : null;
+          const aidesRating = indices.aides >= 0
+            ? parseFeedbackRatingCell(columns[indices.aides])
+            : null;
+          const waitingRating = indices.waiting >= 0
+            ? parseFeedbackRatingCell(columns[indices.waiting])
+            : null;
+
+          const hasRating = [overallRating, doctorsRating, nursesRating, aidesRating, waitingRating]
+            .some((value) => Number.isFinite(value));
+          const hasContact = aidesContact === true || aidesContact === false;
+          const hasRespondent = respondent.length > 0;
+
+          if (!dateValue && !hasRating && !hasRespondent && !hasContact) {
+            return null;
+          }
+
+          return {
+            receivedAt: dateValue,
+            respondent,
+            overallRating: Number.isFinite(overallRating) ? overallRating : null,
+            doctorsRating: Number.isFinite(doctorsRating) ? doctorsRating : null,
+            nursesRating: Number.isFinite(nursesRating) ? nursesRating : null,
+            aidesContact: hasContact ? aidesContact : null,
+            aidesRating: Number.isFinite(aidesRating) ? aidesRating : null,
+            waitingRating: Number.isFinite(waitingRating) ? waitingRating : null,
+          };
+        })
+        .filter(Boolean);
+    }
+
+    async function fetchFeedbackData() {
+      const config = settings?.dataSource?.feedback || DEFAULT_SETTINGS.dataSource.feedback;
+      const url = (config?.url ?? '').trim();
+      const useFallback = Boolean(config?.useFallback);
+      const fallbackCsv = typeof config?.fallbackCsv === 'string'
+        ? config.fallbackCsv
+        : DEFAULT_SETTINGS.dataSource.feedback.fallbackCsv;
+      const fallbackContent = useFallback ? fallbackCsv : '';
+
+      if (!url) {
+        if (fallbackContent) {
+          try {
+            const dataset = transformFeedbackCsv(fallbackContent);
+            dashboardState.feedback.usingFallback = true;
+            dashboardState.feedback.lastErrorMessage = TEXT.feedback.status.missingUrl;
+            return dataset;
+          } catch (error) {
+            console.error('Klaida skaitant demonstracinius atsiliepimus:', error);
+            dashboardState.feedback.usingFallback = false;
+            dashboardState.feedback.lastErrorMessage = describeError(error);
+            return [];
+          }
+        }
+        dashboardState.feedback.usingFallback = false;
+        dashboardState.feedback.lastErrorMessage = '';
+        return [];
+      }
+
+      try {
+        const csvText = await downloadCsv(url);
+        const dataset = transformFeedbackCsv(csvText);
+        dashboardState.feedback.usingFallback = false;
+        dashboardState.feedback.lastErrorMessage = '';
+        return dataset;
+      } catch (error) {
+        console.error('Nepavyko atsisiųsti atsiliepimų CSV:', error);
+        const friendly = describeError(error);
+        dashboardState.feedback.lastErrorMessage = friendly;
+        if (fallbackContent) {
+          try {
+            const dataset = transformFeedbackCsv(fallbackContent);
+            dashboardState.feedback.usingFallback = true;
+            return dataset;
+          } catch (fallbackError) {
+            console.error('Klaida skaitant demonstracinius atsiliepimų duomenis:', fallbackError);
+            dashboardState.feedback.usingFallback = false;
+            dashboardState.feedback.lastErrorMessage = describeError(fallbackError);
+            return [];
+          }
+        }
+        dashboardState.feedback.usingFallback = false;
+        return [];
+      }
+    }
+
     /**
      * Grąžina tik paskutines N dienų įrašus (pagal vėliausią turimą datą).
      * @param {Array<{date: string}>} dailyStats
@@ -3539,6 +4065,137 @@
       });
 
       return Array.from(monthlyMap.values()).sort((a, b) => (a.month > b.month ? 1 : -1));
+    }
+
+    function computeFeedbackStats(records) {
+      const list = Array.isArray(records) ? records.filter(Boolean) : [];
+      const sorted = list
+        .slice()
+        .sort((a, b) => {
+          const aTime = a?.receivedAt instanceof Date ? a.receivedAt.getTime() : -Infinity;
+          const bTime = b?.receivedAt instanceof Date ? b.receivedAt.getTime() : -Infinity;
+          return bTime - aTime;
+        });
+
+      const totalResponses = sorted.length;
+      const collectValues = (key, predicate = null) => sorted
+        .filter((entry) => (typeof predicate === 'function' ? predicate(entry) : true))
+        .map((entry) => {
+          const value = entry?.[key];
+          return Number.isFinite(value) ? Number(value) : null;
+        })
+        .filter((value) => Number.isFinite(value));
+
+      const overallRatings = collectValues('overallRating');
+      const doctorsRatings = collectValues('doctorsRating');
+      const nursesRatings = collectValues('nursesRating');
+      const aidesRatings = collectValues('aidesRating', (entry) => entry?.aidesContact === true);
+      const waitingRatings = collectValues('waitingRating');
+
+      const average = (values) => (values.length
+        ? values.reduce((sum, value) => sum + value, 0) / values.length
+        : null);
+
+      const contactResponses = sorted
+        .filter((entry) => entry?.aidesContact === true || entry?.aidesContact === false)
+        .length;
+      const contactYes = sorted.filter((entry) => entry?.aidesContact === true).length;
+      const contactShare = contactResponses > 0 ? contactYes / contactResponses : null;
+
+      const monthlyMap = new Map();
+      sorted.forEach((entry) => {
+        if (!(entry?.receivedAt instanceof Date) || Number.isNaN(entry.receivedAt.getTime())) {
+          return;
+        }
+        const dateKey = formatLocalDateKey(entry.receivedAt);
+        if (!dateKey) {
+          return;
+        }
+        const monthKey = dateKey.slice(0, 7);
+        if (!monthKey) {
+          return;
+        }
+        if (!monthlyMap.has(monthKey)) {
+          monthlyMap.set(monthKey, {
+            month: monthKey,
+            responses: 0,
+            overallSum: 0,
+            overallCount: 0,
+            doctorsSum: 0,
+            doctorsCount: 0,
+            nursesSum: 0,
+            nursesCount: 0,
+            aidesSum: 0,
+            aidesCount: 0,
+            waitingSum: 0,
+            waitingCount: 0,
+            contactResponses: 0,
+            contactYes: 0,
+          });
+        }
+
+        const bucket = monthlyMap.get(monthKey);
+        bucket.responses += 1;
+
+        if (Number.isFinite(entry?.overallRating)) {
+          bucket.overallSum += Number(entry.overallRating);
+          bucket.overallCount += 1;
+        }
+        if (Number.isFinite(entry?.doctorsRating)) {
+          bucket.doctorsSum += Number(entry.doctorsRating);
+          bucket.doctorsCount += 1;
+        }
+        if (Number.isFinite(entry?.nursesRating)) {
+          bucket.nursesSum += Number(entry.nursesRating);
+          bucket.nursesCount += 1;
+        }
+        if (entry?.aidesContact === true && Number.isFinite(entry?.aidesRating)) {
+          bucket.aidesSum += Number(entry.aidesRating);
+          bucket.aidesCount += 1;
+        }
+        if (Number.isFinite(entry?.waitingRating)) {
+          bucket.waitingSum += Number(entry.waitingRating);
+          bucket.waitingCount += 1;
+        }
+        if (entry?.aidesContact === true) {
+          bucket.contactResponses += 1;
+          bucket.contactYes += 1;
+        } else if (entry?.aidesContact === false) {
+          bucket.contactResponses += 1;
+        }
+      });
+
+      const monthly = Array.from(monthlyMap.values()).map((bucket) => ({
+        month: bucket.month,
+        responses: bucket.responses,
+        overallAverage: bucket.overallCount > 0 ? bucket.overallSum / bucket.overallCount : null,
+        doctorsAverage: bucket.doctorsCount > 0 ? bucket.doctorsSum / bucket.doctorsCount : null,
+        nursesAverage: bucket.nursesCount > 0 ? bucket.nursesSum / bucket.nursesCount : null,
+        aidesAverage: bucket.aidesCount > 0 ? bucket.aidesSum / bucket.aidesCount : null,
+        waitingAverage: bucket.waitingCount > 0 ? bucket.waitingSum / bucket.waitingCount : null,
+        contactResponses: bucket.contactResponses,
+        contactShare: bucket.contactResponses > 0 ? bucket.contactYes / bucket.contactResponses : null,
+      }));
+
+      return {
+        summary: {
+          totalResponses,
+          overallAverage: average(overallRatings),
+          doctorsAverage: average(doctorsRatings),
+          nursesAverage: average(nursesRatings),
+          aidesAverage: average(aidesRatings),
+          waitingAverage: average(waitingRatings),
+          overallCount: overallRatings.length,
+          doctorsCount: doctorsRatings.length,
+          nursesCount: nursesRatings.length,
+          aidesResponses: aidesRatings.length,
+          waitingCount: waitingRatings.length,
+          contactResponses,
+          contactYes,
+          contactShare,
+        },
+        monthly,
+      };
     }
 
     function aggregatePeriodSummary(entries) {
@@ -4768,6 +5425,149 @@
       syncCompareActivation();
     }
 
+    function renderFeedbackSection(feedbackData) {
+      if (selectors.feedbackCards) {
+        selectors.feedbackCards.replaceChildren();
+        const summary = feedbackData?.summary ?? {};
+        const cardsConfig = Array.isArray(TEXT.feedback.cards) ? TEXT.feedback.cards : [];
+
+        cardsConfig.forEach((config) => {
+          if (!config || typeof config !== 'object') {
+            return;
+          }
+
+          const rawValue = summary?.[config.key];
+          let value = null;
+          if (Number.isFinite(rawValue)) {
+            switch (config.format) {
+              case 'percent':
+                value = percentFormatter.format(rawValue);
+                break;
+              case 'integer':
+                value = numberFormatter.format(Math.round(rawValue));
+                break;
+              case 'decimal':
+              default:
+                value = oneDecimalFormatter.format(rawValue);
+                break;
+            }
+          }
+
+          const card = document.createElement('article');
+          card.className = 'feedback-card';
+          card.setAttribute('role', 'listitem');
+
+          const title = document.createElement('p');
+          title.className = 'feedback-card__title';
+          title.textContent = config.title;
+
+          const metric = document.createElement('p');
+          metric.className = 'feedback-card__value';
+          metric.textContent = value ?? config.empty;
+
+          const meta = document.createElement('p');
+          meta.className = 'feedback-card__meta';
+          const metaParts = [config.description];
+          if (config.countKey) {
+            const count = summary?.[config.countKey];
+            if (Number.isFinite(count) && count > 0) {
+              metaParts.push(`n=${numberFormatter.format(Math.round(count))}`);
+            }
+          }
+          meta.textContent = metaParts.join(' • ');
+
+          card.append(title, metric, meta);
+          selectors.feedbackCards.appendChild(card);
+        });
+      }
+
+      if (!selectors.feedbackTable) {
+        return;
+      }
+
+      selectors.feedbackTable.replaceChildren();
+      const monthly = Array.isArray(feedbackData?.monthly) ? feedbackData.monthly.slice() : [];
+      if (!monthly.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        const headerCells = selectors.feedbackTable.parentElement?.querySelectorAll('thead th').length || 1;
+        cell.colSpan = Math.max(1, headerCells);
+        cell.className = 'feedback-empty';
+        cell.textContent = TEXT.feedback.table.empty;
+        row.appendChild(cell);
+        selectors.feedbackTable.appendChild(row);
+        return;
+      }
+
+      const placeholder = TEXT.feedback.table.placeholder || '—';
+      const formatAverage = (value) => {
+        if (Number.isFinite(value)) {
+          return oneDecimalFormatter.format(value);
+        }
+        return placeholder;
+      };
+
+      monthly
+        .sort((a, b) => {
+          if (a?.month === b?.month) {
+            return 0;
+          }
+          return a?.month > b?.month ? -1 : 1;
+        })
+        .forEach((entry) => {
+          const row = document.createElement('tr');
+
+          const monthCell = document.createElement('td');
+          monthCell.textContent = typeof entry?.month === 'string' && entry.month
+            ? formatMonthLabel(entry.month)
+            : placeholder;
+
+          const responsesCell = document.createElement('td');
+          responsesCell.textContent = Number.isFinite(entry?.responses)
+            ? numberFormatter.format(Math.round(entry.responses))
+            : placeholder;
+
+          const overallCell = document.createElement('td');
+          overallCell.textContent = formatAverage(entry?.overallAverage);
+
+          const doctorsCell = document.createElement('td');
+          doctorsCell.textContent = formatAverage(entry?.doctorsAverage);
+
+          const nursesCell = document.createElement('td');
+          nursesCell.textContent = formatAverage(entry?.nursesAverage);
+
+          const aidesCell = document.createElement('td');
+          aidesCell.textContent = formatAverage(entry?.aidesAverage);
+
+          const waitingCell = document.createElement('td');
+          waitingCell.textContent = formatAverage(entry?.waitingAverage);
+
+          const contactCell = document.createElement('td');
+          if (Number.isFinite(entry?.contactShare)) {
+            const base = percentFormatter.format(entry.contactShare);
+            const sample = Number.isFinite(entry?.contactResponses) && entry.contactResponses > 0
+              ? ` (n=${numberFormatter.format(Math.round(entry.contactResponses))})`
+              : '';
+            contactCell.textContent = `${base}${sample}`;
+          } else {
+            contactCell.textContent = placeholder;
+          }
+
+          row.append(
+            monthCell,
+            responsesCell,
+            overallCell,
+            doctorsCell,
+            nursesCell,
+            aidesCell,
+            waitingCell,
+            contactCell,
+          );
+
+          selectors.feedbackTable.appendChild(row);
+        });
+    }
+
     function drawFunnelShape(canvas, steps, accentColor, textColor) {
       if (!canvas) {
         return;
@@ -4911,7 +5711,25 @@
     async function loadDashboard() {
       try {
         setStatus('loading');
-        const rawData = await fetchData();
+        const [dataResult, feedbackResult] = await Promise.allSettled([
+          fetchData(),
+          fetchFeedbackData(),
+        ]);
+
+        if (dataResult.status !== 'fulfilled') {
+          throw dataResult.reason;
+        }
+
+        const rawData = dataResult.value;
+        const feedbackRecords = feedbackResult.status === 'fulfilled' ? feedbackResult.value : [];
+        if (feedbackResult.status === 'rejected') {
+          console.error('Nepavyko apdoroti atsiliepimų duomenų:', feedbackResult.reason);
+          if (!dashboardState.feedback.lastErrorMessage) {
+            dashboardState.feedback.lastErrorMessage = describeError(feedbackResult.reason);
+          }
+          dashboardState.feedback.usingFallback = false;
+        }
+
         const dailyStats = computeDailyStats(rawData);
         dashboardState.rawRecords = rawData;
         dashboardState.dailyStats = dailyStats;
@@ -4942,7 +5760,12 @@
           ? monthlyStats.slice(-monthsLimit)
           : monthlyStats;
         renderMonthlyTable(limitedMonthlyStats);
+        const feedbackStats = computeFeedbackStats(feedbackRecords);
+        dashboardState.feedback.summary = feedbackStats.summary;
+        dashboardState.feedback.monthly = feedbackStats.monthly;
+        renderFeedbackSection(feedbackStats);
         setStatus('success');
+        applyFeedbackStatusNote();
       } catch (error) {
         console.error('Nepavyko apdoroti duomenų:', error);
         dashboardState.usingFallback = false;


### PR DESCRIPTION
## Summary
- localize the feedback section texts for aggregated cards and a monthly summary table
- compute feedback statistics without exposing individual responses and render monthly rows with sample sizes
- set the default feedback CSV URL to the published Google Sheet provided by the department

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da163e8cc083208497cf905f5f3fbd