### PR TITLE
Tighten hero header spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
       background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.16), transparent 55%),
                   linear-gradient(135deg, #081231, #0b1d4d);
       color: #fff;
-      padding: 32px 0 24px;
+      padding: 20px 0 16px;
       position: relative;
       overflow: hidden;
     }
@@ -92,52 +92,52 @@
 
     .hero__content {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       justify-content: space-between;
-      gap: 32px;
+      gap: 24px;
       position: relative;
       z-index: 1;
     }
 
     .hero__title {
-      font-size: clamp(1.6rem, 1.2rem + 1.1vw, 2.2rem);
-      margin: 0 0 8px;
+      font-size: clamp(1.5rem, 1.1rem + 1vw, 2rem);
+      margin: 0 0 4px;
       letter-spacing: -0.01em;
     }
 
     .hero__subtitle {
       margin: 0;
-      font-size: 0.95rem;
-      color: rgba(255, 255, 255, 0.9);
-      max-width: 520px;
+      font-size: 0.9rem;
+      color: rgba(255, 255, 255, 0.85);
+      max-width: 460px;
     }
 
     .hero__actions {
       display: flex;
       flex-direction: column;
       align-items: flex-end;
-      gap: 10px;
+      gap: 6px;
     }
 
     .hero__buttons {
       display: flex;
       align-items: center;
       justify-content: flex-end;
-      gap: 12px;
+      gap: 8px;
       flex-wrap: wrap;
     }
 
     button.icon-button {
       border: none;
       border-radius: 50%;
-      width: 44px;
-      height: 44px;
+      width: 40px;
+      height: 40px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
       cursor: pointer;
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, border-color 0.3s ease;
-      box-shadow: 0 12px 30px -20px rgba(15, 23, 42, 0.7);
+      box-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.7);
       padding: 0;
     }
 
@@ -225,9 +225,9 @@
     }
 
     .status {
-      margin-top: 8px;
-      font-size: 0.85rem;
-      color: rgba(255, 255, 255, 0.85);
+      margin-top: 4px;
+      font-size: 0.82rem;
+      color: rgba(255, 255, 255, 0.82);
     }
 
     .status--error {
@@ -266,7 +266,7 @@
     /* Mobile header adjustments */
     @media (max-width: 640px) {
       header.hero {
-        padding: 20px 0 18px;
+        padding: 16px 0 14px;
       }
 
       .hero__content {
@@ -298,8 +298,8 @@
       }
 
       .hero__buttons button.icon-button {
-        width: 40px;
-        height: 40px;
+        width: 36px;
+        height: 36px;
       }
 
       .status {


### PR DESCRIPTION
## Summary
- reduce hero header padding and gaps for a more compact layout
- shrink icon button sizes and spacing to match the condensed design
- tune mobile header paddings and button sizing for consistency across breakpoints

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68da876b30c483209ed18ec198130819