### PR TITLE
Expand dashboard layout to use full screen width

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,8 +71,11 @@
     }
 
     .container {
-      width: min(1220px, 92vw);
+      width: 100%;
+      max-width: 100%;
       margin: 0 auto;
+      padding-left: clamp(16px, 3vw, 48px);
+      padding-right: clamp(16px, 3vw, 48px);
     }
 
     .section-nav {
@@ -88,12 +91,12 @@
     }
 
     .section-nav__bar {
-      width: min(1220px, 92vw);
+      width: 100%;
       margin: 0 auto;
       display: flex;
       align-items: center;
       gap: 16px;
-      padding: 10px 0;
+      padding: 10px clamp(16px, 3vw, 48px);
     }
 
     .section-nav__title {


### PR DESCRIPTION
## Summary
- update the shared container to span the full viewport width with responsive side padding
- align the section navigation bar spacing with the full-width layout so content uses the screen edge-to-edge

## Testing
- not run (static page)


------
https://chatgpt.com/codex/tasks/task_e_68dbc6aeaed483209737808c683e4bc7