### PR TITLE
Fix sticky hero overlap when navigating sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@
     #recentHeading,
     #monthlyHeading,
     #feedbackHeading {
-      scroll-margin-top: calc(var(--section-nav-height, 0px) + 16px);
+      scroll-margin-top: calc(var(--hero-height, 0px) + 16px);
     }
 
     .section__subtitle {
@@ -3290,7 +3290,10 @@
       if (sectionObserver) {
         sectionObserver.disconnect();
       }
-      const topOffset = Math.max(0, Math.round(layoutMetrics.nav));
+      const topOffset = Math.max(
+        0,
+        Math.round(Math.max(layoutMetrics.hero || 0, layoutMetrics.nav || 0)),
+      );
       sectionObserver = new IntersectionObserver(handleSectionIntersection, {
         rootMargin: `-${topOffset}px 0px -55% 0px`,
         threshold: [0.1, 0.25, 0.5, 0.75, 1],


### PR DESCRIPTION
## Summary
- adjust section heading scroll margin to account for the sticky hero height so sections start unobstructed
- align the section observer offset with the hero height to keep active navigation states in sync

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc1e5c88c08320b3f5a712fedae758