### PR TITLE
Fix feedback section rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -8447,6 +8447,207 @@
       });
     }
 
+    function formatFeedbackCardValue(value, format) {
+      let numericValue = null;
+      if (Number.isFinite(value)) {
+        numericValue = value;
+      } else if (typeof value === 'string') {
+        const parsed = Number.parseFloat(value.replace(',', '.'));
+        if (Number.isFinite(parsed)) {
+          numericValue = parsed;
+        }
+      }
+
+      if (numericValue == null) {
+        return null;
+      }
+
+      switch (format) {
+        case 'decimal':
+          return decimalFormatter.format(numericValue);
+        case 'integer':
+          return numberFormatter.format(Math.round(numericValue));
+        case 'percent':
+          return percentFormatter.format(numericValue);
+        default:
+          return decimalFormatter.format(numericValue);
+      }
+    }
+
+    function renderFeedbackCards(summary) {
+      if (!selectors.feedbackCards) {
+        return;
+      }
+
+      const cardsConfig = Array.isArray(TEXT.feedback?.cards)
+        ? TEXT.feedback.cards
+        : [];
+
+      selectors.feedbackCards.replaceChildren();
+
+      if (!cardsConfig.length) {
+        const empty = document.createElement('p');
+        empty.className = 'feedback-empty';
+        empty.textContent = TEXT.feedback?.empty || 'Kol kas nėra apibendrintų atsiliepimų.';
+        selectors.feedbackCards.appendChild(empty);
+        return;
+      }
+
+      const summaryData = summary && typeof summary === 'object' ? summary : {};
+      const hasValues = cardsConfig.some((card) => {
+        if (!card || typeof card !== 'object') {
+          return false;
+        }
+        const raw = summaryData[card.key];
+        const formatted = formatFeedbackCardValue(raw, card.format);
+        if (formatted != null) {
+          return true;
+        }
+        if (Number.isFinite(raw)) {
+          return true;
+        }
+        return false;
+      });
+
+      if (!hasValues) {
+        const empty = document.createElement('p');
+        empty.className = 'feedback-empty';
+        empty.textContent = TEXT.feedback?.empty || 'Kol kas nėra apibendrintų atsiliepimų.';
+        selectors.feedbackCards.appendChild(empty);
+        return;
+      }
+
+      const responsesLabel = TEXT.feedback?.table?.headers?.responses || 'Atsakymai';
+
+      cardsConfig.forEach((card) => {
+        if (!card || typeof card !== 'object') {
+          return;
+        }
+
+        const cardElement = document.createElement('article');
+        cardElement.className = 'feedback-card';
+        cardElement.setAttribute('role', 'listitem');
+
+        const title = document.createElement('p');
+        title.className = 'feedback-card__title';
+        title.textContent = card.title || '';
+
+        const valueElement = document.createElement('p');
+        valueElement.className = 'feedback-card__value';
+        const rawValue = summaryData[card.key];
+        const formattedValue = formatFeedbackCardValue(rawValue, card.format);
+        const fallbackText = card.empty || TEXT.feedback?.empty || '—';
+        valueElement.textContent = formattedValue != null ? formattedValue : fallbackText;
+
+        const metaElement = document.createElement('p');
+        metaElement.className = 'feedback-card__meta';
+        const metaParts = [];
+        if (card.description) {
+          metaParts.push(card.description);
+        }
+        if (card.countKey) {
+          const rawCount = summaryData[card.countKey];
+          let numericCount = null;
+          if (Number.isFinite(rawCount)) {
+            numericCount = rawCount;
+          } else if (typeof rawCount === 'string') {
+            const parsedCount = Number.parseFloat(rawCount.replace(',', '.'));
+            if (Number.isFinite(parsedCount)) {
+              numericCount = parsedCount;
+            }
+          }
+          if (Number.isFinite(numericCount)) {
+            metaParts.push(`${responsesLabel}: ${numberFormatter.format(Math.round(numericCount))}`);
+          }
+        }
+        const nodes = [title, valueElement];
+        if (metaParts.length) {
+          metaElement.textContent = metaParts.join(' • ');
+          nodes.push(metaElement);
+        }
+        nodes.forEach((node) => {
+          cardElement.appendChild(node);
+        });
+        selectors.feedbackCards.appendChild(cardElement);
+      });
+    }
+
+    function renderFeedbackTable(monthlyStats) {
+      if (!selectors.feedbackTable) {
+        return;
+      }
+
+      selectors.feedbackTable.replaceChildren();
+
+      const placeholder = TEXT.feedback?.table?.placeholder || '—';
+
+      if (!Array.isArray(monthlyStats) || !monthlyStats.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 8;
+        cell.textContent = TEXT.feedback?.table?.empty || TEXT.feedback?.empty || 'Kol kas nėra apibendrintų atsiliepimų.';
+        row.appendChild(cell);
+        selectors.feedbackTable.appendChild(row);
+        return;
+      }
+
+      const formatRating = (value) => {
+        if (Number.isFinite(value)) {
+          return decimalFormatter.format(value);
+        }
+        return placeholder;
+      };
+
+      monthlyStats
+        .slice()
+        .sort((a, b) => b.month.localeCompare(a.month))
+        .forEach((entry) => {
+          const row = document.createElement('tr');
+          const monthLabel = formatMonthLabel(entry?.month || '');
+          const displayMonth = monthLabel || entry?.month || placeholder;
+          const responsesValue = Number.isFinite(entry?.responses) ? entry.responses : null;
+          const contactResponses = Number.isFinite(entry?.contactResponses) ? entry.contactResponses : null;
+          const contactShare = Number.isFinite(entry?.contactShare) ? entry.contactShare : null;
+          let contactText = placeholder;
+          if (contactResponses != null && contactShare != null) {
+            contactText = `${numberFormatter.format(Math.round(contactResponses))} (${percentFormatter.format(contactShare)})`;
+          } else if (contactResponses != null) {
+            contactText = numberFormatter.format(Math.round(contactResponses));
+          } else if (contactShare != null) {
+            contactText = percentFormatter.format(contactShare);
+          }
+
+          row.innerHTML = `
+            <td>${displayMonth}</td>
+            <td>${responsesValue != null ? numberFormatter.format(Math.round(responsesValue)) : placeholder}</td>
+            <td>${formatRating(entry.overallAverage)}</td>
+            <td>${formatRating(entry.doctorsAverage)}</td>
+            <td>${formatRating(entry.nursesAverage)}</td>
+            <td>${formatRating(entry.aidesAverage)}</td>
+            <td>${formatRating(entry.waitingAverage)}</td>
+            <td>${contactText}</td>
+          `;
+
+          selectors.feedbackTable.appendChild(row);
+        });
+    }
+
+    function renderFeedbackSection(feedbackStats) {
+      const summary = feedbackStats && typeof feedbackStats.summary === 'object'
+        ? feedbackStats.summary
+        : null;
+      const monthly = Array.isArray(feedbackStats?.monthly)
+        ? feedbackStats.monthly
+        : [];
+
+      renderFeedbackCards(summary);
+      renderFeedbackTable(monthly);
+
+      renderFeedbackTrendChart(monthly).catch((error) => {
+        console.error('Nepavyko atvaizduoti atsiliepimų trendo:', error);
+      });
+    }
+
     async function renderFeedbackTrendChart(monthlyStats) {
       const canvas = selectors.feedbackTrendChart || document.getElementById('feedbackTrendChart');
       const messageElement = selectors.feedbackTrendMessage || document.getElementById('feedbackTrendMessage');


### PR DESCRIPTION
## Summary
- add rendering helpers to populate the feedback cards and monthly table when data is loaded
- render the feedback trend chart from the new section renderer and guard against missing data

## Testing
- not run (static HTML)

------
https://chatgpt.com/codex/tasks/task_e_68de818ff5148320b452fb9b674e3946