### PR TITLE
Fix settings bootstrap and expose KPI filter helpers

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -9,6 +9,9 @@ import {
   FEEDBACK_RATING_MAX,
   FEEDBACK_LEGACY_MAX,
   TEXT,
+  getDefaultKpiFilters,
+  sanitizeKpiFilters,
+  setConfigSettings,
 } from './config.js';
 
 preloadChartJs();
@@ -186,6 +189,12 @@ const heroCompactState = {
   enterOffset: 160,
   exitOffset: 100,
 };
+
+/**
+ * Aktyvūs nustatymai (užkraunami iš LocalStorage ir sinchronizuojami su config.js helperiais).
+ */
+let settings = loadSettings();
+setConfigSettings(settings);
 
 function computeVisibleRatio(rect) {
   if (!rect) {
@@ -1233,6 +1242,7 @@ function handleSettingsSubmit(event) {
   }
   const extracted = extractSettingsFromForm(selectors.settingsForm);
   settings = normalizeSettings(extracted);
+  setConfigSettings(settings);
   const previousFilters = dashboardState.kpi.filters;
   const defaultFilters = getDefaultKpiFilters();
   dashboardState.kpi.filters = {
@@ -1258,6 +1268,7 @@ function handleResetSettings() {
     return;
   }
   settings = normalizeSettings({});
+  setConfigSettings(settings);
   dashboardState.kpi.filters = getDefaultKpiFilters();
   refreshKpiWindowOptions();
   syncKpiFilterControls();


### PR DESCRIPTION
## Summary
- remove the direct loadSettings call from config and add a setter for active settings
- export KPI filter helpers and make them respect the latest settings snapshot
- initialize settings in app.js, sync them with the config cache, and update the sync on save/reset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3dbed615483209254d7cc63684663