### PR TITLE
Fix mobile navigation state after CSV reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -5423,6 +5423,41 @@
       });
     }
 
+    function reconcileMobileNavState() {
+      const panel = selectors.mobileNavPanel;
+      if (!panel) {
+        document.body.removeAttribute('data-mobile-nav-open');
+        mobileNavState.open = false;
+        mobileNavState.focusables = [];
+        mobileNavState.focusReturn = null;
+        return;
+      }
+
+      const panelHasOpenFlag = panel.getAttribute('data-open') === 'true';
+      const panelIsHidden = panel.hasAttribute('hidden') || panel.hidden === true;
+      const panelOpenInDom = panelHasOpenFlag && !panelIsHidden;
+      const bodyMarkedOpen = document.body.getAttribute('data-mobile-nav-open') === 'true';
+
+      if (!panelOpenInDom) {
+        if (bodyMarkedOpen) {
+          document.body.removeAttribute('data-mobile-nav-open');
+        }
+        if (mobileNavState.open) {
+          mobileNavState.open = false;
+          mobileNavState.focusables = [];
+          mobileNavState.focusReturn = null;
+          if (selectors.mobileNavToggle) {
+            const openLabel = settings.output.mobileNavOpenLabel || TEXT.mobileNav.open;
+            selectors.mobileNavToggle.setAttribute('aria-expanded', 'false');
+            selectors.mobileNavToggle.setAttribute('aria-label', openLabel);
+            selectors.mobileNavToggle.title = openLabel;
+          }
+        }
+      } else if (!bodyMarkedOpen) {
+        document.body.setAttribute('data-mobile-nav-open', 'true');
+      }
+    }
+
     function updateMobileNavActiveState(headingId) {
       if (!mobileNavState.links || !mobileNavState.links.length) {
         return;
@@ -5471,6 +5506,7 @@
       if (mobileNavState.open) {
         mobileNavState.focusables = collectMobileNavFocusables();
       }
+      reconcileMobileNavState();
     }
 
     function closeMobileNavPanel(options = {}) {
@@ -5493,6 +5529,7 @@
         mobileNavState.focusReturn.focus({ preventScroll: true });
       }
       mobileNavState.focusReturn = null;
+      reconcileMobileNavState();
     }
 
     function openMobileNavPanel() {
@@ -5524,6 +5561,7 @@
       if (initialFocus && typeof initialFocus.focus === 'function') {
         initialFocus.focus({ preventScroll: true });
       }
+      reconcileMobileNavState();
     }
 
     function toggleMobileNavPanel() {
@@ -5603,6 +5641,7 @@
           mobileNavState.mediaQuery.addListener(handleMobileNavMediaChange);
         }
       }
+      reconcileMobileNavState();
     }
 
     function syncSectionNavVisibility() {
@@ -13254,6 +13293,8 @@
         dashboardState.lastErrorMessage = friendlyMessage;
         setStatus('error', friendlyMessage);
         await renderEdDashboard(dashboardState.ed);
+      } finally {
+        reconcileMobileNavState();
       }
     }
 


### PR DESCRIPTION
## Summary
- add a reconciliation helper to keep the mobile navigation overlay state in sync with the DOM
- invoke the reconciliation after nav link refresh/open/close/init and when data loading finishes to avoid the blurred overlay getting stuck

## Testing
- manual Playwright scenario (mobile viewport) verifying the nav can reopen after data reload

------
https://chatgpt.com/codex/tasks/task_e_68e41e0af5bc83209f9c8a041e56a2da