### PR TITLE
Fix mobile navigation labels and add yearly link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1719,6 +1719,7 @@
     #chartHeading,
     #recentHeading,
     #monthlyHeading,
+    #yearlyHeading,
     #feedbackHeading {
       scroll-margin-top: calc(var(--hero-height, 0px) + 16px);
     }
@@ -3561,6 +3562,7 @@
             <a class="section-nav__link" href="#chartHeading">Grafikai</a>
             <a class="section-nav__link" href="#recentHeading">Paskutinės dienos</a>
             <a class="section-nav__link" href="#monthlyHeading">Mėnesiai</a>
+            <a class="section-nav__link" href="#yearlyHeading">Metinė suvestinė</a>
             <a class="section-nav__link" href="#feedbackHeading">Atsiliepimai</a>
           </div>
         </div>
@@ -5398,6 +5400,26 @@
       selectors.sectionNav.dataset.keyboard = 'bound';
     }
 
+    function getMobileNavLabels() {
+      const openLabel = settings.output.mobileNavOpenLabel || TEXT.mobileNav.open;
+      const closeLabel = settings.output.mobileNavCloseLabel || TEXT.mobileNav.close;
+      return { openLabel, closeLabel };
+    }
+
+    function updateMobileNavToggleLabels(isOpen = mobileNavState.open) {
+      if (!selectors.mobileNavToggle) {
+        return;
+      }
+      const { openLabel, closeLabel } = getMobileNavLabels();
+      const activeLabel = isOpen ? closeLabel : openLabel;
+      selectors.mobileNavToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      selectors.mobileNavToggle.setAttribute('aria-label', activeLabel);
+      selectors.mobileNavToggle.title = activeLabel;
+      if (selectors.mobileNavToggleLabel) {
+        selectors.mobileNavToggleLabel.textContent = activeLabel;
+      }
+    }
+
     function isMobileNavViewport() {
       if (mobileNavState.mediaQuery && typeof mobileNavState.mediaQuery.matches === 'boolean') {
         return mobileNavState.mediaQuery.matches;
@@ -5446,15 +5468,13 @@
           mobileNavState.open = false;
           mobileNavState.focusables = [];
           mobileNavState.focusReturn = null;
-          if (selectors.mobileNavToggle) {
-            const openLabel = settings.output.mobileNavOpenLabel || TEXT.mobileNav.open;
-            selectors.mobileNavToggle.setAttribute('aria-expanded', 'false');
-            selectors.mobileNavToggle.setAttribute('aria-label', openLabel);
-            selectors.mobileNavToggle.title = openLabel;
-          }
+          updateMobileNavToggleLabels(false);
         }
       } else if (!bodyMarkedOpen) {
         document.body.setAttribute('data-mobile-nav-open', 'true');
+      }
+      if (!panelOpenInDom) {
+        updateMobileNavToggleLabels(false);
       }
     }
 
@@ -5517,12 +5537,7 @@
       selectors.mobileNavPanel.removeAttribute('data-open');
       selectors.mobileNavPanel.hidden = true;
       document.body.removeAttribute('data-mobile-nav-open');
-      if (selectors.mobileNavToggle) {
-        selectors.mobileNavToggle.setAttribute('aria-expanded', 'false');
-        const openLabel = settings.output.mobileNavOpenLabel || TEXT.mobileNav.open;
-        selectors.mobileNavToggle.setAttribute('aria-label', openLabel);
-        selectors.mobileNavToggle.title = openLabel;
-      }
+      updateMobileNavToggleLabels(false);
       mobileNavState.open = false;
       mobileNavState.focusables = [];
       if (restoreFocus && mobileNavState.focusReturn && typeof mobileNavState.focusReturn.focus === 'function') {
@@ -5546,12 +5561,7 @@
       selectors.mobileNavPanel.hidden = false;
       selectors.mobileNavPanel.setAttribute('data-open', 'true');
       document.body.setAttribute('data-mobile-nav-open', 'true');
-      if (selectors.mobileNavToggle) {
-        selectors.mobileNavToggle.setAttribute('aria-expanded', 'true');
-        const closeLabel = settings.output.mobileNavCloseLabel || TEXT.mobileNav.close;
-        selectors.mobileNavToggle.setAttribute('aria-label', closeLabel);
-        selectors.mobileNavToggle.title = closeLabel;
-      }
+      updateMobileNavToggleLabels(true);
       mobileNavState.open = true;
       mobileNavState.focusReturn = document.activeElement instanceof HTMLElement ? document.activeElement : null;
       mobileNavState.focusables = collectMobileNavFocusables();
@@ -5614,7 +5624,6 @@
       }
       selectors.mobileNavPanel.hidden = true;
       selectors.mobileNavPanel.removeAttribute('data-open');
-      selectors.mobileNavToggle.setAttribute('aria-expanded', 'false');
       selectors.mobileNavPanel.addEventListener('keydown', handleMobileNavKeydown);
       selectors.mobileNavToggle.addEventListener('click', (event) => {
         event.preventDefault();
@@ -5642,6 +5651,7 @@
         }
       }
       reconcileMobileNavState();
+      updateMobileNavToggleLabels(false);
     }
 
     function syncSectionNavVisibility() {
@@ -5754,6 +5764,36 @@
 
       updateLayoutMetrics();
       syncSectionNavVisibility();
+    }
+
+    function syncNavLinkLabels() {
+      const navLinks = (selectors.sectionNavLinks && selectors.sectionNavLinks.length)
+        ? selectors.sectionNavLinks
+        : Array.from(document.querySelectorAll('.section-nav__link'));
+      if (!navLinks || !navLinks.length) {
+        return;
+      }
+      navLinks.forEach((link) => {
+        if (!(link instanceof HTMLAnchorElement)) {
+          return;
+        }
+        const href = link.getAttribute('href') || '';
+        if (!href.startsWith('#')) {
+          return;
+        }
+        const headingId = href.slice(1);
+        const headingEl = headingId ? document.getElementById(headingId) : null;
+        if (!headingEl) {
+          return;
+        }
+        const label = (headingEl.textContent || '').trim();
+        if (label.length > 0) {
+          link.textContent = label;
+        }
+      });
+      if (sectionNavState.initialized) {
+        refreshMobileNavLinks();
+      }
     }
 
     function cloneSettings(value) {
@@ -6671,17 +6711,7 @@
           selectors.closeEdPanelBtn.textContent = closeLabel;
         }
       }
-      if (selectors.mobileNavToggleLabel) {
-        selectors.mobileNavToggleLabel.textContent = settings.output.mobileNavOpenLabel || TEXT.mobileNav.open;
-      }
-      if (selectors.mobileNavToggle) {
-        const openLabel = settings.output.mobileNavOpenLabel || TEXT.mobileNav.open;
-        const closeLabel = settings.output.mobileNavCloseLabel || TEXT.mobileNav.close;
-        const activeLabel = mobileNavState.open ? closeLabel : openLabel;
-        selectors.mobileNavToggle.setAttribute('aria-expanded', mobileNavState.open ? 'true' : 'false');
-        selectors.mobileNavToggle.setAttribute('aria-label', activeLabel);
-        selectors.mobileNavToggle.title = activeLabel;
-      }
+      updateMobileNavToggleLabels();
       if (selectors.mobileNavTitle) {
         selectors.mobileNavTitle.textContent = settings.output.mobileNavTitle || TEXT.mobileNav.title;
       }
@@ -6693,6 +6723,7 @@
         selectors.mobileNavCloseBtn.setAttribute('aria-label', closeLabel);
         selectors.mobileNavCloseBtn.title = closeLabel;
       }
+      syncNavLinkLabels();
       if (selectors.edTvToggleBtn) {
         const toggleTexts = TEXT.edTv?.toggle || {};
         const isActive = dashboardState.tvMode === true;


### PR DESCRIPTION
## Summary
- add the yearly summary section to the primary navigation and adjust scroll offsets for the new anchor
- synchronise section link labels with their headings so navigation text reflects settings updates
- ensure the mobile navigation toggle updates its visible label/aria state when the panel opens or closes

## Testing
- Manual mobile check via Playwright

------
https://chatgpt.com/codex/tasks/task_e_68e49fe91dd08320a6bb886d99e964e3