### PR TITLE
Organize ED dashboard into icon-labelled sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,32 @@
       opacity: 1;
     }
 
+    body[data-theme="dark"] .ed-dashboard__section {
+      background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.78));
+      border-color: rgba(96, 165, 250, 0.2);
+      box-shadow: 0 34px 72px -36px rgba(8, 12, 32, 0.9);
+    }
+
+    body[data-theme="dark"] .ed-dashboard__section-icon {
+      background: rgba(96, 165, 250, 0.2);
+      color: rgba(191, 219, 254, 0.95);
+      box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.35);
+    }
+
+    body[data-theme="dark"] .ed-dashboard__section-title {
+      text-shadow: 0 4px 16px rgba(8, 12, 32, 0.9);
+    }
+
+    body[data-theme="dark"] .ed-dashboard__section-description {
+      color: rgba(226, 232, 240, 0.92);
+    }
+
+    body[data-theme="dark"] .ed-dashboard__card-title,
+    body[data-theme="dark"] .ed-dashboard__card-value,
+    body[data-theme="dark"] .ed-dashboard__card-meta {
+      text-shadow: 0 4px 18px rgba(5, 8, 22, 0.85);
+    }
+
     .ed-dashboard__summary {
       display: flex;
       flex-wrap: wrap;
@@ -370,25 +396,27 @@
       display: inline-flex;
       align-items: center;
       gap: 10px;
-      padding: 8px 16px;
+      padding: 10px 20px;
       border-radius: 999px;
       background: rgba(37, 99, 235, 0.12);
       color: var(--color-accent);
-      font-weight: 600;
-      letter-spacing: 0.015em;
-      font-size: 0.85rem;
+      font-weight: 700;
+      letter-spacing: 0.035em;
+      font-size: clamp(1rem, 1.5vw, 1.12rem);
       line-height: 1.3;
       border: 1px solid rgba(37, 99, 235, 0.16);
       transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+      text-transform: uppercase;
+      text-shadow: 0 2px 8px rgba(37, 99, 235, 0.25);
     }
 
     .ed-dashboard__status::before {
       content: '';
-      width: 10px;
-      height: 10px;
+      width: 12px;
+      height: 12px;
       border-radius: 50%;
       background: currentColor;
-      box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+      box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.15);
     }
 
     .ed-dashboard__status[data-tone="success"] {
@@ -445,8 +473,12 @@
 
     .ed-dashboard__status-meta {
       margin: 0;
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
+      font-size: clamp(0.95rem, 1.3vw, 1.05rem);
+      color: var(--color-text);
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      text-transform: uppercase;
+      text-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
     }
 
     .ed-dashboard__status-meta[hidden] {
@@ -519,9 +551,74 @@
     }
 
     .ed-dashboard__cards {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(24px, 3vw, 32px);
+    }
+
+    .ed-dashboard__section {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(16px, 2vw, 24px);
+      padding: clamp(20px, 3vw, 28px);
+      border-radius: 24px;
+      background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(226, 232, 255, 0.82));
+      border: 1px solid rgba(37, 99, 235, 0.14);
+      box-shadow: 0 28px 60px -34px rgba(15, 23, 42, 0.55);
+    }
+
+    .ed-dashboard__section-header {
+      display: flex;
+      align-items: center;
+      gap: clamp(16px, 2.5vw, 24px);
+    }
+
+    .ed-dashboard__section-header-text {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .ed-dashboard__section-icon {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: clamp(52px, 6vw, 64px);
+      height: clamp(52px, 6vw, 64px);
+      border-radius: 18px;
+      background: var(--color-accent-soft);
+      color: var(--color-accent);
+      box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25);
+    }
+
+    .ed-dashboard__section-icon svg {
+      width: 70%;
+      height: 70%;
+    }
+
+    .ed-dashboard__section-title {
+      margin: 0;
+      font-size: clamp(1.4rem, 2.3vw, 1.7rem);
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--color-text);
+      text-shadow: 0 4px 12px rgba(15, 23, 42, 0.18);
+    }
+
+    .ed-dashboard__section-description {
+      margin: 4px 0 0;
+      font-size: clamp(1rem, 1.6vw, 1.15rem);
+      color: var(--color-text);
+      opacity: 0.8;
+      max-width: 70ch;
+    }
+
+    .ed-dashboard__section-grid {
       display: grid;
       gap: clamp(16px, 2vw, 24px);
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 
     .ed-dashboard__card {
@@ -529,53 +626,59 @@
       overflow: hidden;
       border-radius: 20px;
       padding: clamp(18px, 2vw, 26px);
-      background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 255, 0.8));
-      border: 1px solid rgba(37, 99, 235, 0.08);
-      box-shadow: 0 24px 50px -32px rgba(15, 23, 42, 0.55);
+      background: linear-gradient(150deg, rgba(255, 255, 255, 0.97), rgba(226, 232, 255, 0.88));
+      border: 1px solid rgba(37, 99, 235, 0.18);
+      box-shadow: 0 32px 60px -34px rgba(15, 23, 42, 0.6);
       display: flex;
       flex-direction: column;
-      gap: 8px;
-      min-height: 150px;
+      gap: clamp(10px, 1.6vw, 16px);
+      min-height: 160px;
     }
 
     .ed-dashboard__card::after {
       content: '';
       position: absolute;
       inset: 0;
-      background: linear-gradient(160deg, rgba(37, 99, 235, 0.08), rgba(37, 99, 235, 0));
-      opacity: 0.65;
+      background: linear-gradient(165deg, rgba(37, 99, 235, 0.12), rgba(37, 99, 235, 0));
+      opacity: 0.7;
       pointer-events: none;
     }
 
     body[data-theme="dark"] .ed-dashboard__card {
-      background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.75));
-      border-color: rgba(96, 165, 250, 0.12);
-      box-shadow: 0 26px 60px -32px rgba(8, 12, 32, 0.9);
+      background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.78));
+      border-color: rgba(96, 165, 250, 0.18);
+      box-shadow: 0 34px 70px -36px rgba(8, 12, 32, 0.9);
     }
 
     body[data-theme="dark"] .ed-dashboard__card::after {
       background: linear-gradient(160deg, rgba(96, 165, 250, 0.12), rgba(96, 165, 250, 0));
-      opacity: 0.9;
+      opacity: 0.85;
     }
 
     .ed-dashboard__card-title {
       margin: 0;
-      font-size: 0.92rem;
-      font-weight: 600;
-      color: var(--color-text-muted);
+      font-size: clamp(1.05rem, 1.6vw, 1.25rem);
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      color: var(--color-text);
+      text-shadow: 0 3px 10px rgba(15, 23, 42, 0.25);
     }
 
     .ed-dashboard__card-value {
       margin: 0;
-      font-size: clamp(1.6rem, 2.8vw, 2.1rem);
-      font-weight: 700;
+      font-size: clamp(2rem, 3.6vw, 2.8rem);
+      font-weight: 800;
       color: var(--color-text);
+      text-shadow: 0 6px 16px rgba(15, 23, 42, 0.3);
     }
 
     .ed-dashboard__card-meta {
       margin: 0;
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
+      font-size: clamp(0.95rem, 1.4vw, 1.08rem);
+      color: var(--color-text);
+      opacity: 0.85;
+      line-height: 1.4;
     }
 
     .ed-dashboard__card-meta:empty {
@@ -3874,7 +3977,7 @@
           </div>
           <div class="ed-dashboard__layout">
             <div class="ed-dashboard__column ed-dashboard__column--metrics">
-              <div id="edCards" class="ed-dashboard__cards" role="list"></div>
+              <div id="edCards" class="ed-dashboard__cards"></div>
             </div>
             <div class="ed-dashboard__column ed-dashboard__column--charts ed-dashboard__tables">
               <section class="ed-dashboard__group" aria-labelledby="edDispositionsTitle">
@@ -4316,6 +4419,28 @@
           error: (reason) => `Nepavyko įkelti ED duomenų: ${reason}`,
           noUrl: 'Nenurodytas ED duomenų URL. Rodomi demonstraciniai duomenys.',
         },
+        cardSections: {
+          default: {
+            title: 'Skydelio rodikliai',
+            description: 'Pagrindiniai ED rodikliai',
+            icon: 'flow',
+          },
+          flow: {
+            title: 'Pacientų srautas',
+            description: 'Paros apkrova, momentinė situacija ir hospitalizacijų dalys.',
+            icon: 'flow',
+          },
+          staffing: {
+            title: 'Komanda ir lovos',
+            description: 'Lovų užimtumas ir personalo apkrovos rodikliai.',
+            icon: 'staffing',
+          },
+          efficiency: {
+            title: 'Procesų trukmės',
+            description: 'Vidutiniai laukimo ir buvimo laiko rodikliai.',
+            icon: 'efficiency',
+          },
+        },
         cards: {
           legacy: [
             {
@@ -4324,20 +4449,7 @@
               description: 'Skaičiuojama pagal dienas, kuriose yra duomenų.',
               empty: '—',
               format: 'oneDecimal',
-            },
-            {
-              key: 'avgLosMinutes',
-              title: 'Vid. buvimo trukmė',
-              description: 'Vidutinė buvimo trukmė skyriuje (val.).',
-              empty: '—',
-              format: 'hours',
-            },
-            {
-              key: 'avgDoorToProviderMinutes',
-              title: 'Vid. iki gydytojo',
-              description: 'Vidutinis „durys iki gydytojo“ laikas (min.).',
-              empty: '—',
-              format: 'minutes',
+              section: 'flow',
             },
             {
               key: 'hospitalizedShare',
@@ -4345,20 +4457,7 @@
               description: 'Pacientų dalis, kuriems prireikė stacionaro.',
               empty: '—',
               format: 'percent',
-            },
-            {
-              key: 'avgLosMonthMinutes',
-              title: 'Vid. laikas skyriuje (šis mėn.)',
-              description: 'Šio mėnesio vidutinė buvimo trukmė (val.).',
-              empty: '—',
-              format: 'hours',
-            },
-            {
-              key: 'hospitalizedMonthShare',
-              title: 'Hospitalizacijų dalis (šis mėn.)',
-              description: 'Šio mėnesio hospitalizacijų dalis.',
-              empty: '—',
-              format: 'percent',
+              section: 'flow',
             },
             {
               key: 'avgDaytimePatientsMonth',
@@ -4366,6 +4465,39 @@
               description: 'Pagal dienos pamainos momentinius įrašus.',
               empty: '—',
               format: 'oneDecimal',
+              section: 'flow',
+            },
+            {
+              key: 'hospitalizedMonthShare',
+              title: 'Hospitalizacijų dalis (šis mėn.)',
+              description: 'Šio mėnesio hospitalizacijų dalis.',
+              empty: '—',
+              format: 'percent',
+              section: 'flow',
+            },
+            {
+              key: 'avgLosMinutes',
+              title: 'Vid. buvimo trukmė',
+              description: 'Vidutinė buvimo trukmė skyriuje (val.).',
+              empty: '—',
+              format: 'hours',
+              section: 'efficiency',
+            },
+            {
+              key: 'avgDoorToProviderMinutes',
+              title: 'Vid. iki gydytojo',
+              description: 'Vidutinis „durys iki gydytojo“ laikas (min.).',
+              empty: '—',
+              format: 'minutes',
+              section: 'efficiency',
+            },
+            {
+              key: 'avgLosMonthMinutes',
+              title: 'Vid. laikas skyriuje (šis mėn.)',
+              description: 'Šio mėnesio vidutinė buvimo trukmė (val.).',
+              empty: '—',
+              format: 'hours',
+              section: 'efficiency',
             },
             {
               key: 'avgLabMonthMinutes',
@@ -4373,6 +4505,7 @@
               description: 'Šio mėnesio laboratorinių tyrimų trukmė (min.).',
               empty: '—',
               format: 'minutes',
+              section: 'efficiency',
             },
           ],
           snapshot: [
@@ -4381,6 +4514,7 @@
               title: 'Pacientai skyriuje dabar',
               description: '',
               empty: '—',
+              section: 'flow',
             },
             {
               key: 'occupiedBeds',
@@ -4388,6 +4522,7 @@
               description: '',
               empty: '—',
               format: 'beds',
+              section: 'staffing',
             },
             {
               key: 'nursePatientsPerStaff',
@@ -4395,6 +4530,7 @@
               description: 'Pacientai vienai slaugytojai.',
               empty: '—',
               format: 'ratio',
+              section: 'staffing',
             },
             {
               key: 'doctorPatientsPerStaff',
@@ -4402,6 +4538,7 @@
               description: 'Pacientai vienam gydytojui.',
               empty: '—',
               format: 'ratio',
+              section: 'staffing',
             },
             {
               key: 'avgLosMonthMinutes',
@@ -4409,6 +4546,7 @@
               description: 'Šio mėnesio vidutinė buvimo trukmė (val.).',
               empty: '—',
               format: 'hours',
+              section: 'efficiency',
             },
             {
               key: 'hospitalizedMonthShare',
@@ -4416,6 +4554,7 @@
               description: 'Šio mėnesio hospitalizacijų dalis.',
               empty: '—',
               format: 'percent',
+              section: 'flow',
             },
             {
               key: 'avgDaytimePatientsMonth',
@@ -4423,6 +4562,7 @@
               description: 'Pagal dienos pamainos momentinius įrašus.',
               empty: '—',
               format: 'oneDecimal',
+              section: 'flow',
             },
             {
               key: 'avgLabMonthMinutes',
@@ -4430,6 +4570,7 @@
               description: 'Šio mėnesio laboratorinių tyrimų trukmė (min.).',
               empty: '—',
               format: 'minutes',
+              section: 'efficiency',
             },
           ],
         },
@@ -12598,20 +12739,72 @@
         message = TEXT.ed.status.success(successTimestamp);
         tone = 'success';
       }
-      return {
-        message,
-        tone,
-        timestamp: timestampText,
-        statusDate,
-        updatedAt,
-        hasEntries,
-      };
-    }
+    return {
+      message,
+      tone,
+      timestamp: timestampText,
+      statusDate,
+      updatedAt,
+      hasEntries,
+    };
+  }
 
-    async function renderEdDashboard(edData) {
-      if (!selectors.edPanel) {
-        return;
-      }
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+
+  const edSectionIconDefinitions = {
+    flow(svg) {
+      svg.appendChild(createSvgElement('path', { d: 'M7 7h10' }));
+      svg.appendChild(createSvgElement('path', { d: 'M7 17h10' }));
+      svg.appendChild(createSvgElement('polyline', { points: '7 7 3 11 7 15' }));
+      svg.appendChild(createSvgElement('polyline', { points: '17 7 21 11 17 15' }));
+    },
+    efficiency(svg) {
+      svg.appendChild(createSvgElement('circle', { cx: '12', cy: '12', r: '9' }));
+      svg.appendChild(createSvgElement('polyline', { points: '12 7 12 12 15 15' }));
+    },
+    staffing(svg) {
+      svg.appendChild(createSvgElement('circle', { cx: '8', cy: '9', r: '3' }));
+      svg.appendChild(createSvgElement('circle', { cx: '16', cy: '9', r: '3' }));
+      svg.appendChild(createSvgElement('path', { d: 'M3 20v-1.5a5.5 5.5 0 0 1 5.5-5.5H11' }));
+      svg.appendChild(createSvgElement('path', { d: 'M21 20v-1.5A5.5 5.5 0 0 0 15.5 13H13' }));
+    },
+    default(svg) {
+      svg.appendChild(createSvgElement('circle', { cx: '12', cy: '12', r: '9' }));
+      svg.appendChild(createSvgElement('path', { d: 'M12 7v10' }));
+      svg.appendChild(createSvgElement('path', { d: 'M7 12h10' }));
+    },
+  };
+
+  function createSvgElement(type, attributes = {}) {
+    const element = document.createElementNS(SVG_NS, type);
+    Object.entries(attributes).forEach(([key, value]) => {
+      element.setAttribute(key, String(value));
+    });
+    element.setAttribute('stroke-linecap', 'round');
+    element.setAttribute('stroke-linejoin', 'round');
+    return element;
+  }
+
+  function createEdSectionIcon(iconKey) {
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '1.8');
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.setAttribute('focusable', 'false');
+    const iconName = iconKey && edSectionIconDefinitions[iconKey]
+      ? iconKey
+      : 'default';
+    edSectionIconDefinitions[iconName](svg);
+    return svg;
+  }
+
+  async function renderEdDashboard(edData) {
+    if (!selectors.edPanel) {
+      return;
+    }
       const dataset = edData || {};
       const summary = dataset.summary || createEmptyEdSummary(dataset.meta?.type);
       const dispositions = Array.isArray(dataset.dispositions) ? dataset.dispositions : [];
@@ -12666,69 +12859,150 @@
 
       if (selectors.edCards) {
         selectors.edCards.replaceChildren();
+        const sectionDefinitions = TEXT.ed.cardSections || {};
+        const sectionsMap = new Map();
+
         cardConfigs.forEach((config) => {
           if (!config || typeof config !== 'object') {
             return;
           }
-          const card = document.createElement('article');
-          card.className = 'ed-dashboard__card';
-          card.setAttribute('role', 'listitem');
+          const sectionKey = config.section || 'default';
+          if (!sectionsMap.has(sectionKey)) {
+            const sectionMeta = sectionDefinitions[sectionKey] || sectionDefinitions.default || {};
+            sectionsMap.set(sectionKey, {
+              key: sectionKey,
+              title: sectionMeta.title || '',
+              description: sectionMeta.description || '',
+              icon: sectionMeta.icon || '',
+              cards: [],
+            });
+          }
+          sectionsMap.get(sectionKey).cards.push(config);
+        });
 
-          const title = document.createElement('p');
-          title.className = 'ed-dashboard__card-title';
-          title.textContent = config.title;
+        const groupedSections = Array.from(sectionsMap.values());
+        if (!groupedSections.length && cardConfigs.length) {
+          groupedSections.push({
+            key: 'default',
+            title: sectionDefinitions?.default?.title || '',
+            description: sectionDefinitions?.default?.description || '',
+            icon: sectionDefinitions?.default?.icon || '',
+            cards: cardConfigs.filter((config) => config && typeof config === 'object'),
+          });
+        }
 
-          const value = document.createElement('p');
-          value.className = 'ed-dashboard__card-value';
-          const primaryRaw = summary?.[config.key];
-          const secondaryRaw = config.secondaryKey ? summary?.[config.secondaryKey] : undefined;
-          let hasValue = false;
-          if (config.secondaryKey) {
-            const primaryFormatted = formatEdCardValue(primaryRaw, config.format);
-            const secondaryFormatted = formatEdCardValue(secondaryRaw, config.format);
-            const suffix = config.format === 'hours'
-              ? ' val.'
-              : (config.format === 'minutes' ? ' min.' : '');
-            const primaryText = primaryFormatted != null
-              ? `${primaryFormatted}${suffix}`
-              : '—';
-            const secondaryText = secondaryFormatted != null
-              ? `${secondaryFormatted}${suffix}`
-              : '—';
-            if (primaryFormatted != null || secondaryFormatted != null) {
-              value.textContent = `${primaryText} / ${secondaryText}`;
-              hasValue = true;
+        groupedSections.forEach((section, sectionIndex) => {
+          if (!Array.isArray(section.cards) || !section.cards.length) {
+            return;
+          }
+          const sectionEl = document.createElement('section');
+          sectionEl.className = 'ed-dashboard__section';
+          sectionEl.setAttribute('role', 'region');
+
+          const shouldRenderHeader = Boolean(section.title || section.description || groupedSections.length > 1);
+          let sectionLabelId = '';
+          if (shouldRenderHeader) {
+            const header = document.createElement('header');
+            header.className = 'ed-dashboard__section-header';
+
+            const iconWrapper = document.createElement('span');
+            iconWrapper.className = 'ed-dashboard__section-icon';
+            const iconKey = section.icon || (section.key !== 'default' ? section.key : 'default');
+            iconWrapper.appendChild(createEdSectionIcon(iconKey));
+            header.appendChild(iconWrapper);
+
+            const textWrapper = document.createElement('div');
+            textWrapper.className = 'ed-dashboard__section-header-text';
+            const titleEl = document.createElement('h3');
+            sectionLabelId = `edSectionTitle-${String(section.key || sectionIndex).replace(/[^a-z0-9_-]/gi, '') || sectionIndex}`;
+            titleEl.className = 'ed-dashboard__section-title';
+            titleEl.id = sectionLabelId;
+            titleEl.textContent = section.title || sectionDefinitions?.default?.title || TEXT.ed.title || 'RŠL SMPS skydelis';
+            textWrapper.appendChild(titleEl);
+
+            if (section.description || sectionDefinitions?.default?.description) {
+              const descriptionEl = document.createElement('p');
+              descriptionEl.className = 'ed-dashboard__section-description';
+              descriptionEl.textContent = section.description || sectionDefinitions?.default?.description || '';
+              textWrapper.appendChild(descriptionEl);
             }
-          } else {
-            const formatted = formatEdCardValue(primaryRaw, config.format);
-            if (formatted != null) {
-              if (config.format === 'hours') {
-                value.textContent = `${formatted} val.`;
-              } else if (config.format === 'minutes') {
-                value.textContent = `${formatted} min.`;
-              } else {
-                value.textContent = formatted;
+
+            header.appendChild(textWrapper);
+            sectionEl.appendChild(header);
+            sectionEl.setAttribute('aria-labelledby', sectionLabelId);
+          }
+
+          const cardsWrapper = document.createElement('div');
+          cardsWrapper.className = 'ed-dashboard__section-grid';
+          cardsWrapper.setAttribute('role', 'list');
+          if (sectionLabelId) {
+            cardsWrapper.setAttribute('aria-labelledby', sectionLabelId);
+          }
+
+          section.cards.forEach((config) => {
+            const card = document.createElement('article');
+            card.className = 'ed-dashboard__card';
+            card.setAttribute('role', 'listitem');
+
+            const title = document.createElement('p');
+            title.className = 'ed-dashboard__card-title';
+            title.textContent = config.title;
+
+            const value = document.createElement('p');
+            value.className = 'ed-dashboard__card-value';
+            const primaryRaw = summary?.[config.key];
+            const secondaryRaw = config.secondaryKey ? summary?.[config.secondaryKey] : undefined;
+            let hasValue = false;
+            if (config.secondaryKey) {
+              const primaryFormatted = formatEdCardValue(primaryRaw, config.format);
+              const secondaryFormatted = formatEdCardValue(secondaryRaw, config.format);
+              const suffix = config.format === 'hours'
+                ? ' val.'
+                : (config.format === 'minutes' ? ' min.' : '');
+              const primaryText = primaryFormatted != null
+                ? `${primaryFormatted}${suffix}`
+                : '—';
+              const secondaryText = secondaryFormatted != null
+                ? `${secondaryFormatted}${suffix}`
+                : '—';
+              if (primaryFormatted != null || secondaryFormatted != null) {
+                value.textContent = `${primaryText} / ${secondaryText}`;
+                hasValue = true;
               }
-              hasValue = true;
+            } else {
+              const formatted = formatEdCardValue(primaryRaw, config.format);
+              if (formatted != null) {
+                if (config.format === 'hours') {
+                  value.textContent = `${formatted} val.`;
+                } else if (config.format === 'minutes') {
+                  value.textContent = `${formatted} min.`;
+                } else {
+                  value.textContent = formatted;
+                }
+                hasValue = true;
+              }
             }
-          }
-          if (!hasValue) {
-            value.textContent = config.empty ?? '—';
-          }
+            if (!hasValue) {
+              value.textContent = config.empty ?? '—';
+            }
 
-          const meta = document.createElement('p');
-          meta.className = 'ed-dashboard__card-meta';
-          meta.textContent = config.description || '';
+            const meta = document.createElement('p');
+            meta.className = 'ed-dashboard__card-meta';
+            meta.textContent = config.description || '';
 
-          card.append(title, value);
+            card.append(title, value);
 
-          const visuals = buildEdCardVisuals(config, primaryRaw, secondaryRaw);
-          visuals.forEach((node) => {
-            card.appendChild(node);
+            const visuals = buildEdCardVisuals(config, primaryRaw, secondaryRaw);
+            visuals.forEach((node) => {
+              card.appendChild(node);
+            });
+
+            card.appendChild(meta);
+            cardsWrapper.appendChild(card);
           });
 
-          card.appendChild(meta);
-          selectors.edCards.appendChild(card);
+          sectionEl.appendChild(cardsWrapper);
+          selectors.edCards.appendChild(sectionEl);
         });
       }
 


### PR DESCRIPTION
## Summary
- group the RŠL SMPS dashboard metrics into themed sections with icon headers for quicker scanning
- boost typography contrast and spacing so ED cards and status text stay legible from a distance
- add reusable SVG icon helpers and section metadata so future metrics can slot into the new layout easily

## Testing
- No automated tests (static HTML dashboard)


------
https://chatgpt.com/codex/tasks/task_e_68e548478fc08320bf2f5f58d967801a