### PR TITLE
Add daytime hourly metric and lab fallback for ED cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -4499,6 +4499,14 @@
               section: 'flow',
             },
             {
+              key: 'avgDaytimePatientsPerHour',
+              title: 'Vid. pacientų per val. (dieną)',
+              description: 'Dienos pamainos vidurkis vienai valandai.',
+              empty: '—',
+              format: 'oneDecimal',
+              section: 'flow',
+            },
+            {
               key: 'hospitalizedMonthShare',
               title: 'Hospitalizacijų dalis (šis mėn.)',
               description: 'Šio mėnesio hospitalizacijų dalis.',
@@ -4607,6 +4615,14 @@
               key: 'avgDaytimePatientsMonth',
               title: 'Vid. pacientų dieną (šis mėn.)',
               description: '',
+              empty: '—',
+              format: 'oneDecimal',
+              section: 'flow',
+            },
+            {
+              key: 'avgDaytimePatientsPerHour',
+              title: 'Vid. pacientų per val. (dieną)',
+              description: 'Dienos pamainos vidurkis vienai valandai.',
               empty: '—',
               format: 'oneDecimal',
               section: 'flow',
@@ -7431,6 +7447,20 @@
       };
     }
 
+    function computeDayShiftMinutes(calculationSettings = {}) {
+      const dayMinutes = 24 * 60;
+      const { startMinutes, endMinutes } = resolveNightBoundsMinutes(calculationSettings);
+      if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) {
+        return dayMinutes;
+      }
+      let nightDuration = endMinutes - startMinutes;
+      if (nightDuration <= 0) {
+        nightDuration += dayMinutes;
+      }
+      const dayDuration = dayMinutes - nightDuration;
+      return dayDuration > 0 ? dayDuration : dayMinutes;
+    }
+
     function isNightTimestamp(date, nightStartMinutes, nightEndMinutes) {
       if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
         return null;
@@ -8320,6 +8350,7 @@
         totalPatients: 0,
         uniqueDates: 0,
         avgDailyPatients: null,
+        avgDaytimePatientsPerHour: null,
         avgLosMinutes: null,
         avgLosHospitalizedMinutes: null,
         avgLosMonthMinutes: null,
@@ -8968,20 +8999,65 @@
         }
       }
 
+      const dayShiftMinutes = computeDayShiftMinutes(settings?.calculations);
+      const dayShiftHours = dayShiftMinutes / 60;
+      let snapshotDaytimeAverage = null;
+
       const targetMonth = summary.currentMonthKey || latestSnapshotMonth;
-      if (summary.avgDaytimePatientsMonth == null && targetMonth && daytimeSnapshotBuckets.has(targetMonth)) {
+      if (targetMonth && daytimeSnapshotBuckets.has(targetMonth)) {
         const bucket = daytimeSnapshotBuckets.get(targetMonth);
-        summary.avgDaytimePatientsMonth = bucket.count > 0 ? bucket.sum / bucket.count : null;
+        const average = bucket.count > 0 ? bucket.sum / bucket.count : null;
+        snapshotDaytimeAverage = average;
+        if (summary.avgDaytimePatientsMonth == null) {
+          summary.avgDaytimePatientsMonth = average;
+        }
       } else if (
         summary.avgDaytimePatientsMonth == null
         && latestSnapshotMonth
         && daytimeSnapshotBuckets.has(latestSnapshotMonth)
       ) {
         const bucket = daytimeSnapshotBuckets.get(latestSnapshotMonth);
-        summary.avgDaytimePatientsMonth = bucket.count > 0 ? bucket.sum / bucket.count : null;
+        const average = bucket.count > 0 ? bucket.sum / bucket.count : null;
+        snapshotDaytimeAverage = average;
+        summary.avgDaytimePatientsMonth = average;
         if (!summary.currentMonthKey) {
           summary.currentMonthKey = latestSnapshotMonth;
         }
+      }
+
+      if (summary.avgDaytimePatientsMonth == null && Number.isFinite(summary.avgDailyPatients)) {
+        summary.avgDaytimePatientsMonth = summary.avgDailyPatients;
+      }
+
+      if (snapshotDaytimeAverage != null && Number.isFinite(dayShiftHours) && dayShiftHours > 0) {
+        summary.avgDaytimePatientsPerHour = snapshotDaytimeAverage;
+      } else if (
+        summary.avgDaytimePatientsPerHour == null
+        && Number.isFinite(summary.avgDailyPatients)
+        && Number.isFinite(dayShiftHours)
+        && dayShiftHours > 0
+      ) {
+        summary.avgDaytimePatientsPerHour = summary.avgDailyPatients / dayShiftHours;
+      } else if (
+        summary.avgDaytimePatientsPerHour == null
+        && Number.isFinite(summary.avgDaytimePatientsMonth)
+        && Number.isFinite(dayShiftHours)
+        && dayShiftHours > 0
+      ) {
+        summary.avgDaytimePatientsPerHour = summary.avgDaytimePatientsMonth / dayShiftHours;
+      }
+
+      if (
+        summary.avgLabMonthMinutes == null
+        && summary.avgLabYearMinutes != null
+      ) {
+        summary.avgLabMonthMinutes = summary.avgLabYearMinutes;
+      }
+      if (
+        summary.avgLabMonthMinutes == null
+        && summary.avgLabMinutes != null
+      ) {
+        summary.avgLabMonthMinutes = summary.avgLabMinutes;
       }
 
       let dispositions = [];


### PR DESCRIPTION
## Summary
- calculate the daytime shift duration, derive hourly patient averages, and expose them in the ED summary
- surface the new hourly metric in both legacy and snapshot ED card layouts and backfill missing lab averages from yearly/overall data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5868e81e083209705239187d810e6