### PR TITLE
Remove avg daytime patients (this month) card from ED dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -4491,14 +4491,6 @@
               section: 'flow',
             },
             {
-              key: 'avgDaytimePatientsMonth',
-              title: 'Vid. pacientų dieną (šis mėn.)',
-              description: 'Pagal dienos pamainos momentinius įrašus.',
-              empty: '—',
-              format: 'oneDecimal',
-              section: 'flow',
-            },
-            {
               key: 'hospitalizedMonthShare',
               title: 'Hospitalizacijų dalis (šis mėn.)',
               description: 'Šio mėnesio hospitalizacijų dalis.',
@@ -4601,14 +4593,6 @@
               description: 'Naujausių duomenų dalys pagal kategoriją.',
               empty: '—',
               type: 'donut',
-              section: 'flow',
-            },
-            {
-              key: 'avgDaytimePatientsMonth',
-              title: 'Vid. pacientų dieną (šis mėn.)',
-              description: '',
-              empty: '—',
-              format: 'oneDecimal',
               section: 'flow',
             },
             {


### PR DESCRIPTION
## Summary
- remove the "Vid. pacientų dieną (šis mėn.)" card configuration from the RŠL SMPS dashboard legacy cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5ee76d8948320a6c5611ad1c2e167