### PR TITLE
Add 5-minute auto refresh to ED dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Modernizuotas vieno HTML failo informacinis skydelis, kuris užkrauna neatidėli
 
 ## Savybės
 - 🔄 Vienas HTML failas be papildomų priklausomybių (Chart.js kraunamas iš CDN per klasikinį `<script>`, kad neliktų CORS/MIME kliūčių).
+- ⏱️ Automatinis duomenų atnaujinimas kas 5 min., papildomai galima perkrauti rankiniu mygtuku.
 - 🔗 Galimybė kartu naudoti pagrindinį operatyvinį ir papildomą 5 metų istorinį CSV šaltinį.
 - 📊 KPI kortelės su aiškia „Metinis vidurkis“ eilute ir mėnesio palyginimu, stulpelinė bei linijinė diagramos, paskutinės 7 dienos ir savaitinė lentelės.
 - 🗓️ KPI laikotarpio filtras leidžia pasirinkti iki 365 d. langą arba matyti visus duomenis vienu paspaudimu.
@@ -26,6 +27,7 @@ Modernizuotas vieno HTML failo informacinis skydelis, kuris užkrauna neatidėli
 - GMP laukas numatytai atpažįsta reikšmes „GMP“, „su GMP“ ir „GMP (su GMP)“, o tuščias hospitalizavimo stulpelis reiškia išrašytą pacientą.
 - Spalvų schema ir kampai – CSS kintamieji `:root` bloke (`index.html`).
 - Grafikai – Chart.js nustatymai `renderCharts()` funkcijoje (`index.html`).
+- Automatinio atnaujinimo intervalas – `AUTO_REFRESH_INTERVAL_MS` kintamasis `index.html` faile (numatyta 5 min.).
 
 ### Nustatymų meniu
 

--- a/index.html
+++ b/index.html
@@ -4404,6 +4404,8 @@
     const FEEDBACK_RATING_MIN = 1;
     const FEEDBACK_RATING_MAX = 5;
     const FEEDBACK_LEGACY_MAX = 10;
+    const AUTO_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // Automatinio atnaujinimo intervalas (5 min). Keiskite čia, jei reikia kito dažnio.
+    let autoRefreshTimerId = null;
     /**
      * Konfigūracija tekstams ir greitiems pakeitimams (LT numatytasis, lengva išplėsti EN).
      */
@@ -5056,6 +5058,15 @@
         return '';
       }
       return `${trimmed.charAt(0).toUpperCase()}${trimmed.slice(1)}`;
+    }
+
+    function restartAutoRefreshTimer() {
+      if (autoRefreshTimerId) {
+        window.clearInterval(autoRefreshTimerId);
+      }
+      autoRefreshTimerId = window.setInterval(() => {
+        loadDashboard();
+      }, AUTO_REFRESH_INTERVAL_MS);
     }
 
     const selectors = {
@@ -6303,6 +6314,8 @@
      * Čia saugome aktyvius grafikus, kad galėtume juos sunaikinti prieš piešiant naujus.
      */
     const dashboardState = {
+      loading: false,
+      queuedReload: false,
       charts: {
         daily: null,
         dow: null,
@@ -13760,6 +13773,13 @@
     }
 
     async function loadDashboard() {
+      if (dashboardState.loading) {
+        dashboardState.queuedReload = true;
+        return;
+      }
+
+      dashboardState.loading = true;
+
       try {
         setStatus('loading');
         if (selectors.edStatus) {
@@ -13858,6 +13878,15 @@
         dashboardState.lastErrorMessage = friendlyMessage;
         setStatus('error', friendlyMessage);
         await renderEdDashboard(dashboardState.ed);
+      } finally {
+        dashboardState.loading = false;
+        restartAutoRefreshTimer();
+        if (dashboardState.queuedReload) {
+          dashboardState.queuedReload = false;
+          window.setTimeout(() => {
+            loadDashboard();
+          }, 0);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- add a reusable auto-refresh timer that reloads dashboard data every five minutes without overlapping requests
- update the dashboard state management to queue refreshes while a load is in progress and restart the timer after each cycle
- document the default refresh cadence and configuration knob in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5f0b858108320b52ce5667c0cb673